### PR TITLE
Fix fetch url ignoring. 

### DIFF
--- a/integration-tests/tests/fetch/fetch-ignored.ejs
+++ b/integration-tests/tests/fetch/fetch-ignored.ejs
@@ -15,7 +15,10 @@
 	<h1>Ignore urls test</h1>
 	<script>
 		Promise.all([fetch('/some-data'), fetch('/no-server-timings')]).then(() => {
-			SplunkRum.provider.getTracer('default').startSpan('guard-span').end();
+			setTimeout(function() {
+				SplunkRum.provider.getTracer('default').startSpan('guard-span').end();
+				// fetch instrumentation waits for some time (300) before ending spans
+			}, 1000)
 		})
 	</script>
 </body>

--- a/integration-tests/tests/fetch/fetch-ignored.ejs
+++ b/integration-tests/tests/fetch/fetch-ignored.ejs
@@ -18,7 +18,7 @@
 			setTimeout(function() {
 				SplunkRum.provider.getTracer('default').startSpan('guard-span').end();
 				// fetch instrumentation waits for some time (300) before ending spans
-			}, 1000)
+			}, 310)
 		})
 	</script>
 </body>

--- a/src/main.js
+++ b/src/main.js
@@ -129,7 +129,7 @@ if (!window.SplunkRum) {
     
     new WebSocketInstrumentation(provider, pluginConf).patch();
     
-    const fetchInstrumentation = new SplunkFetchInstrumentation(provider, pluginConf);
+    const fetchInstrumentation = new SplunkFetchInstrumentation(pluginConf);
     fetchInstrumentation.setTracerProvider(provider);
     fetchInstrumentation.enable();
 


### PR DESCRIPTION
1. Fetch url ignoring broken at the moment.  Fetch Instrumentation constructor takes config not provider and config.
2. Test for it was also broken because fetch spans are ended 300ms after fetch end in order to make sure timings are present when ending span.  So guard-span arrived before fetch spans and test passed although it was broken.