### PR TITLE
Ignore some asset types during docload

### DIFF
--- a/integration-tests/tests/docload/docload-all.ejs
+++ b/integration-tests/tests/docload/docload-all.ejs
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Test docload</title>
+
+	<%- renderAgent({
+    bufferTimeout: 200
+  }) %>
+  <link rel="stylesheet" href="/integration-tests/assets/css-font-img.css">
+</head>
+<body>
+  <p>Docload</p>
+  <script>
+    function makeHXR(url) {
+      var oReq = new XMLHttpRequest();
+      oReq.open("GET", url);
+      oReq.setRequestHeader('Content-Type', 'text/plain');
+      oReq.send();
+
+      return oReq;
+    }
+
+    makeHXR('/some-data');
+		fetch('/some-data?t=1').then(response => response.json());
+  </script>
+
+  <iframe src="iframe.ejs" frameborder="0"></iframe>  
+	<img src="/integration-tests/assets/splunk-black.png?t=300">
+</body>
+</html>

--- a/integration-tests/tests/docload/docload.spec.js
+++ b/integration-tests/tests/docload/docload.spec.js
@@ -75,5 +75,36 @@ module.exports = {
     await browser.timesMakeSense(docLoad.annotations, 'fetchStart', 'domComplete');
 
     await browser.globals.assertNoErrorSpans();
+  },
+  'resources before load event are correctly captured': async function(browser) {
+    browser.globals.clearReceivedSpans();
+    await browser.url(browser.globals.getUrl('/docload/docload-all.ejs'));
+
+    const docLoad = await browser.globals.findSpan(span => span.name === 'documentLoad');
+    await browser.assert.ok(!!docLoad, 'documentLoad present');
+    
+    //t=300 to defer load event until xhr/fetch/beacon can be potentially sent so we can test that they are not sent
+    const resources = [
+      'css-font-img.css', 'splunk-black.png?t=300', 'iframe.ejs', 'splunk.woff'
+    ];
+    const receivedSpans = await browser.globals.getReceivedSpans();
+    for (const urlEnd of resources) {
+      const resourceSpan = receivedSpans.filter(
+        span => span.tags['http.url'] && span.tags['http.url'].endsWith(urlEnd)
+      )[0];
+      await browser.assert.ok(!!resourceSpan, urlEnd);
+      await browser.assert.strictEqual(docLoad.traceId, resourceSpan.traceId, `${urlEnd} has correct traceId`);
+    }
+
+    // no xhr, fetch, beacon span 
+    // t=1 because otherwise xhr and fetch identical
+    const ignoredResources = ['/some-data', '/some-data?t=1', '/api/v2/spans'];
+    for (const urlEnd of ignoredResources) {
+      const resourceSpan = receivedSpans.filter(
+        span => span.tags['component'] === 'document-load' && span.tags['http.url'] && span.tags['http.url'].endsWith(urlEnd)
+
+      )[0];
+      await browser.assert.not.ok(!!resourceSpan, `${urlEnd} is ignored`);
+    }
   }
 };

--- a/integration-tests/tests/docload/iframe.ejs
+++ b/integration-tests/tests/docload/iframe.ejs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>iframe</title>
+
+</head>
+<body>
+
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "karma-coverage-istanbul-reporter": "^3.0.2",
     "karma-firefox-launcher": "^1.3.0",
     "karma-mocha": "^2.0.1",
-    "karma-rollup-preprocessor": "^7.0.5",
+    "karma-rollup-preprocessor": "7.0.5",
     "karma-spec-reporter": "^0.0.32",
     "karma-websocket-server": "^1.0.0",
     "lighthouse": "^7.0.0",

--- a/src/docload.js
+++ b/src/docload.js
@@ -17,6 +17,7 @@ limitations under the License.
 import {DocumentLoad} from '@opentelemetry/plugin-document-load';
 import {captureTraceParentFromPerformanceEntries} from './servertiming';
 
+const excludedInitiatorTypes = ['beacon', 'fetch', 'xmlhttprequest'];
 
 function addExtraDocLoadTags(span) {
   if (document.referrer && document.referrer !== '') {
@@ -50,5 +51,12 @@ export class SplunkDocumentLoad extends DocumentLoad {
       }
     }
     return answer;
+  }
+
+  _initResourceSpan(resource, parentSpan) {
+    if (excludedInitiatorTypes.indexOf(resource.initiatorType) !== -1) {
+      return;
+    }
+    super._initResourceSpan(resource, parentSpan);
   }
 }


### PR DESCRIPTION
Ignore fetch,xhr, beacon happening before load event.
Fetch,xhr will be reported by their instrumentation and beacon is just noise.