### PR TITLE
Do a safety check before asking for xhr header.

### DIFF
--- a/src/xhrfetch.js
+++ b/src/xhrfetch.js
@@ -26,9 +26,12 @@ export class SplunkXhrPlugin extends XMLHttpRequestInstrumentation {
       // don't care about success/failure, just want to see response headers if they exist
       xhr.addEventListener('readystatechange', function () {
         if (xhr.readyState === xhr.HEADERS_RECEIVED) {
-          const st = xhr.getResponseHeader('server-timing');
-          if (st !== null) {
-            captureTraceParent(st, span);
+          const headers = xhr.getAllResponseHeaders().toLowerCase();
+          if (headers.indexOf('server-timing') !== -1) {
+            const st = xhr.getResponseHeader('server-timing');
+            if (st !== null) {
+              captureTraceParent(st, span);
+            }
           }
         }
       });


### PR DESCRIPTION
Chrome will show and error in console otherwise.
More info: https://trackjs.com/blog/refused-unsafe-header/

Lower casing headers is done because in Safari 10 getAllResponseHeaders is upper case but in all other tested 
browsers it is not.