### PR TITLE
fix: remove missmatched stored logs

### DIFF
--- a/packages/session-recorder/src/OTLPLogExporter.ts
+++ b/packages/session-recorder/src/OTLPLogExporter.ts
@@ -195,10 +195,12 @@ export default class OTLPLogExporter {
 			// Only export logs that belong to the current session
 			if (logItem.sessionId !== this.config.sessionId) {
 				log.debug(
-					'exportQueuedLogs - session mismatch',
+					'exportQueuedLogs - session mismatch, removing log',
 					{ ...logItem, data: '[truncated]' },
 					{ sessionId: this.config.sessionId },
 				)
+				// We have to remove session mismatched logs otherwise storage grows
+				removeQueuedLog(logItem)
 				continue
 			}
 


### PR DESCRIPTION
# Description

Remove missmatched storage logs as otherwise old data stay there and storage grows.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
