### PR TITLE
fix: remove logs and add only relevant ones

### DIFF
--- a/packages/session-recorder/src/export-log-queue.ts
+++ b/packages/session-recorder/src/export-log-queue.ts
@@ -77,13 +77,13 @@ const setQueuedLogs = (queuedLogs: QueuedLog[]): boolean => {
 	return safelySetLocalStorage(QUEUED_LOGS_STORAGE_KEY, JSON.stringify(queuedLogs))
 }
 
-export const removeQueuedLog = (logToRemove: QueuedLog) => {
+export const removeQueuedLog = (logToRemove: QueuedLog): boolean => {
 	const queuedLogs = getQueuedLogs() ?? []
 	const updatedLogs = queuedLogs.filter((logItem) => logItem.requestId !== logToRemove.requestId)
-	setQueuedLogs(updatedLogs)
+	return setQueuedLogs(updatedLogs)
 }
 
-const removeQueuedLogs = () => {
+export const removeQueuedLogs = () => {
 	safelyRemoveFromLocalStorage(QUEUED_LOGS_STORAGE_KEY)
 }
 


### PR DESCRIPTION
# Description

Cap storage by removing all saved queued logs and add only relevant ones.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
