### PR TITLE
feat: stop sending metadata in raw data for splunk recorder

### DIFF
--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -282,12 +282,9 @@ const SplunkRumRecorder = {
 
 			eventCounter += 1
 
-			// TODO: Use when UI is ready to handle only raw data in body
-			// const body = encoder.encode(
-			// 	JSON.stringify(emitContext.type === 'splunk' ? emitContext.data.data : emitContext.data),
-			// )
-
-			const body = encoder.encode(JSON.stringify(emitContext.data))
+			const body = encoder.encode(
+				JSON.stringify(emitContext.type === 'splunk' ? emitContext.data.data : emitContext.data),
+			)
 
 			const totalC = Math.ceil(body.byteLength / MAX_CHUNK_SIZE)
 


### PR DESCRIPTION
# Description

Stop sending metadata in raw data chunk as Splunk recorder and API is using attributes.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
