### PR TITLE
chore(session-replay): add `persistFailedReplayData`

### DIFF
--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -40,6 +40,22 @@ export type SplunkRumRecorderConfig = {
 	debug?: boolean
 
 	/**
+	 * Enables persistence of session replay data when upload requests fail.
+	 *
+	 * When enabled, session replay chunks that fail to upload (due to network issues,
+	 * server errors, or browser issues) are automatically stored in local browser storage
+	 * and retried on subsequent page loads.
+	 *
+	 * This feature helps prevent data loss and ensures comprehensive session coverage
+	 * even in unreliable network conditions. The queue is automatically managed and
+	 * cleaned up after successful uploads.
+	 *
+	 * Storage: Currently the data is stored in localStorage.
+	 * @default true
+	 */
+	persistFailedReplayData?: boolean
+
+	/**
 	 * The name of your organization’s realm. Automatically configures beaconUrl with correct URL
 	 */
 	realm?: string
@@ -170,7 +186,7 @@ const SplunkRumRecorder = {
 				return newAttributes
 			},
 			sessionId: SplunkRum.getSessionId() ?? '',
-			usePersistentExportQueue: true,
+			usePersistentExportQueue: config.persistFailedReplayData ?? true,
 		})
 		const processor = new BatchLogProcessor(exporter)
 


### PR DESCRIPTION
# Description

This PR introduces a new configuration option persistFailedReplayData to the Splunk Session Recorder, allowing users to control whether failed session replay uploads are persisted to local storage for retry attempts.


## Type of change

Delete options that are not relevant.


- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
