### PR TITLE
fix(session-recorder): stop overwriting splunk.rumVersionFull attribute

### DIFF
--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -248,7 +248,7 @@ const SplunkRumRecorder = {
 				SplunkRum.provider.resource.attributes['splunk.sessionReplay'] = 'splunk'
 
 				if (isNextTagUsed && typeof __COMMIT_HASH__ === 'string' && __COMMIT_HASH__) {
-					SplunkRum.provider.resource.attributes['splunk.rumVersionFull'] = __COMMIT_HASH__
+					SplunkRum.provider.resource.attributes['splunk.rumVersionFullSessionRecorder'] = __COMMIT_HASH__
 				}
 			}
 

--- a/packages/web/src/instrumentations/splunk-webvitals-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-webvitals-instrumentation.ts
@@ -136,7 +136,7 @@ export class SplunkWebVitalsInstrumentation extends InstrumentationBase<SplunkWe
 		let span
 		if (this._config.experimental_alignWebVitalsSpansWithDocumentLoad) {
 			const docLoadSpan = await this.docLoadSpanPromise
-			let startTime = Math.round(hrTimeToMilliseconds(docLoadSpan.startTime)) + 1
+			let startTime = hrTimeToMilliseconds(docLoadSpan.startTime) + 1
 			endTime = startTime
 			const sessionState = this.sessionManager?.getSessionMetadata()
 			if (sessionState && sessionState.sessionStart - startTime > 1000 * 60) {

--- a/packages/web/src/instrumentations/splunk-webvitals-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-webvitals-instrumentation.ts
@@ -136,7 +136,7 @@ export class SplunkWebVitalsInstrumentation extends InstrumentationBase<SplunkWe
 		let span
 		if (this._config.experimental_alignWebVitalsSpansWithDocumentLoad) {
 			const docLoadSpan = await this.docLoadSpanPromise
-			let startTime = hrTimeToMilliseconds(docLoadSpan.startTime) + 1
+			let startTime = Math.round(hrTimeToMilliseconds(docLoadSpan.startTime)) + 1
 			endTime = startTime
 			const sessionState = this.sessionManager?.getSessionMetadata()
 			if (sessionState && sessionState.sessionStart - startTime > 1000 * 60) {


### PR DESCRIPTION
# Description
Session-recorder was overwriting `splunk.rumVersionFull` with its own commit hash, which caused confusion when the session-recorder version differed from the agent version. This resulted in spans showing new version strings while exhibiting old code behavior.

Changed to use `splunk.rumVersionFullSessionRecorder` to track the session-recorder version independently.

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
