### PR TITLE
chore: always use crypto-backed ID generation

### DIFF
--- a/packages/integration-tests/src/server/server.ts
+++ b/packages/integration-tests/src/server/server.ts
@@ -125,7 +125,6 @@ fastify.get<{
 			? reply.viewAsync(parsedUrl.pathname, {
 					renderAgent(userOpts = {}, noInit = false, file = defaultFile, cdnVersion = null) {
 						const options: Record<string, unknown> = {
-							_experimental_useCryptoForIds: true,
 							applicationName: 'splunk-otel-js-dummy-app',
 							beaconEndpoint: beaconUrl.toString(),
 							bufferTimeout: GLOBAL_TEST_BUFFER_TIMEOUT,

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -72,7 +72,7 @@ import {
 	SplunkOtelWebOptionsInstrumentations,
 	UserTrackingMode,
 } from './types'
-import { generateId, getPluginConfig, setUseCryptoForIds } from './utils'
+import { generateId, getPluginConfig } from './utils'
 import { getValidAttributes, SpanContext } from './utils/attributes'
 import { isAgentLoadedViaLatestTag, isAgentLoadedViaNextTag } from './utils/detect-latest'
 import { isBot } from './utils/is-bot'
@@ -469,10 +469,6 @@ export const SplunkRum: SplunkOtelWebType = {
 			}
 
 			this._processedOptions = processedOptions
-
-			if (processedOptions._experimental_useCryptoForIds) {
-				setUseCryptoForIds(true)
-			}
 
 			// Initialize picker if this is a picker window
 			if (isPickerWindow()) {

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -127,13 +127,6 @@ export interface SplunkOtelWebConfig {
 				quietTime?: number
 		  }
 
-	/**
-	 * Experimental: If true, uses crypto.getRandomValues() instead of Math.random() for generating IDs.
-	 * This avoids deterministic ID collisions in environments with seeded Math.random() (e.g. Googlebot).
-	 * @default false
-	 */
-	_experimental_useCryptoForIds?: boolean
-
 	/** Allows http beacon urls */
 	allowInsecureBeacon?: boolean
 

--- a/packages/web/src/utils.ts
+++ b/packages/web/src/utils.ts
@@ -20,25 +20,11 @@ import { customAlphabet } from 'nanoid'
 import { wrap } from 'shimmer'
 
 const HEX_ALPHABET = '0123456789abcdef'
-
-let nanoidHex: ((size: number) => string) | undefined
-
-export function setUseCryptoForIds(value: boolean): void {
-	nanoidHex = value ? customAlphabet(HEX_ALPHABET) : undefined
-}
+const nanoidHex = customAlphabet(HEX_ALPHABET)
 
 export function generateId(bits: number): string {
 	const length = bits / 4
-	if (nanoidHex) {
-		return nanoidHex(length)
-	}
-
-	const xes = 'x'.repeat(length)
-	// eslint-disable-next-line unicorn/prefer-string-replace-all
-	return xes.replace(/x/g, function () {
-		// eslint-disable-next-line unicorn/prefer-math-trunc
-		return ((Math.random() * 16) | 0).toString(16)
-	})
+	return nanoidHex(length)
 }
 
 export function limitLen(s: string, cap: number): string {

--- a/packages/web/tests/utils.test.ts
+++ b/packages/web/tests/utils.test.ts
@@ -16,9 +16,9 @@
  *
  */
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { describe, expect, it } from 'vitest'
 
-import { generateId, setUseCryptoForIds } from '../src/utils'
+import { generateId } from '../src/utils'
 
 describe('generateId', () => {
 	it('should generate IDs of 64 and 128 bits', () => {
@@ -33,27 +33,5 @@ describe('generateId', () => {
 	it('should generate unique IDs', () => {
 		const ids = new Set(Array.from({ length: 100 }, () => generateId(128)))
 		expect(ids.size).toBe(100)
-	})
-
-	describe('with crypto disabled', () => {
-		afterEach(() => {
-			setUseCryptoForIds(true)
-		})
-
-		it('should generate valid hex IDs using Math.random fallback', () => {
-			setUseCryptoForIds(false)
-			const id64 = generateId(64)
-			const id128 = generateId(128)
-			expect(id64.length).toBe(16)
-			expect(id128.length).toBe(32)
-			expect(id64.match('^[0-9a-f]+$')).toBeTruthy()
-			expect(id128.match('^[0-9a-f]+$')).toBeTruthy()
-		})
-
-		it('should generate unique IDs using Math.random fallback', () => {
-			setUseCryptoForIds(false)
-			const ids = new Set(Array.from({ length: 100 }, () => generateId(128)))
-			expect(ids.size).toBe(100)
-		})
 	})
 })

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -15,13 +15,7 @@
  * limitations under the License.
  *
  */
-import { afterEach, beforeAll } from 'vitest'
-
-import { setUseCryptoForIds } from '../packages/web/src/utils'
-
-beforeAll(() => {
-	setUseCryptoForIds(true)
-})
+import { afterEach } from 'vitest'
 
 afterEach(() => {
 	delete localStorage['_splunk_rum_sid']


### PR DESCRIPTION
# Description

This change makes the crypto-based ID generator the default behavior. We removed `_experimental_useCryptoForIds` option and deleted the older fallback code, so IDs are now generated in one consistent way everywhere.

See more https://github.com/signalfx/splunk-otel-js-web/pull/1701

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
