### PR TITLE
chore(session-recorder): enable asset caching by default

### DIFF
--- a/packages/session-recorder/src/session-replay/recorder.ts
+++ b/packages/session-recorder/src/session-replay/recorder.ts
@@ -94,7 +94,7 @@ export class Recorder {
 			bindingKey: sessionId,
 			features: {
 				backgroundServiceSrc: backgroundServiceSrc,
-				cacheAssets: this.config.features?.cacheAssets ?? false,
+				cacheAssets: this.config.features?.cacheAssets ?? true,
 				canvas: this.config.features?.canvas ?? false,
 				iframes: this.config.features?.iframes ?? false,
 				packAssets: this.config.features?.packAssets ?? { styles: true },


### PR DESCRIPTION
# Description

Enabling asset caching by default improves replay completeness by avoiding repeated processing of the same discovered assets across page reloads and navigations.


## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
