### PR TITLE
chore: improve dead click detection for role=button and anchor elements

### DIFF
--- a/packages/integration-tests/src/tests/frustration-signals/dead-click.ejs
+++ b/packages/integration-tests/src/tests/frustration-signals/dead-click.ejs
@@ -18,6 +18,8 @@
 		<button id="btn-mutation">Mutation Button</button>
 		<button id="btn-fetch">Fetch Button</button>
 		<a id="link-dead" href="javascript:void(0)">Dead Link</a>
+		<a id="link-with-href" href="/some-page">Link with href</a>
+		<div id="role-button-dead" role="button">Role Button</div>
 		<div id="non-interactive">Non-interactive</div>
 
 		<script>

--- a/packages/integration-tests/src/tests/frustration-signals/frustration-signals.spec.ts
+++ b/packages/integration-tests/src/tests/frustration-signals/frustration-signals.spec.ts
@@ -229,6 +229,28 @@ test.describe('Frustration signals', () => {
 
 			expect(recordPage.receivedSpans.filter(deadClickFilter)).toHaveLength(0)
 		})
+
+		test('Dead click detects click on element with role=button', async ({ recordPage }) => {
+			await recordPage.goTo('/frustration-signals/dead-click.ejs')
+
+			await recordPage.locator('#role-button-dead').click()
+
+			await recordPage.waitForSpans((spans) => spans.some(deadClickFilter))
+
+			const deadClickSpans = recordPage.receivedSpans.filter(deadClickFilter)
+
+			expect(deadClickSpans).toHaveLength(1)
+			expect(deadClickSpans[0].tags['target_xpath']).toBeDefined()
+		})
+
+		test('Dead click does not trigger for anchor with href', async ({ recordPage }) => {
+			await recordPage.goTo('/frustration-signals/dead-click.ejs')
+
+			await recordPage.locator('#link-with-href').click()
+			await recordPage.waitForTimeoutAndFlushData(2000)
+
+			expect(recordPage.receivedSpans.filter(deadClickFilter)).toHaveLength(0)
+		})
 	})
 
 	test.describe('Thrashed cursor', () => {

--- a/packages/web/src/upstream/user-interaction/instrumentation.ts
+++ b/packages/web/src/upstream/user-interaction/instrumentation.ts
@@ -284,13 +284,28 @@ export class UserInteractionInstrumentation<
 	private _isInteractiveElement(element: Element): boolean {
 		const tag = element.tagName.toUpperCase()
 
-		if (tag === 'A' || tag === 'BUTTON') {
+		if (tag === 'BUTTON') {
+			return true
+		}
+
+		if (tag === 'A') {
+			const href = element.getAttribute('href')
+			// <a> with a real href can navigate or open a new tab, so it's not a dead click candidate.
+			// Only <a> with no href or javascript:void(0) is considered interactive for dead-click purposes.
+			if (href && !href.startsWith('javascript:')) {
+				return false
+			}
+
 			return true
 		}
 
 		if (tag === 'INPUT') {
 			const type = (element.getAttribute('type') ?? '').toLowerCase()
 			return type === 'submit'
+		}
+
+		if (element.getAttribute('role') === 'button') {
+			return true
 		}
 
 		return false


### PR DESCRIPTION
# Description

Treat elements with role="button" as interactive so dead clicks are detected on custom button components. Exclude `<a>` elements with a real href from dead click detection since they trigger navigation or can open a new tab — only anchors with no href or javascript: hrefs remain candidates. Added integration tests for both cases.  

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
