### PR TITLE
feat: add `user_agent.is_bot` and `user_agent.is_automated` attributes

### DIFF
--- a/packages/web/src/utils/platform.test.ts
+++ b/packages/web/src/utils/platform.test.ts
@@ -46,6 +46,8 @@ describe('platform utilities', () => {
 
 			const result = getBasicPlatformInfo()
 			expect(result).toEqual({
+				'user_agent.is_automated': false,
+				'user_agent.is_bot': false,
 				'user_agent.language': 'en-US',
 				'user_agent.mobile': false,
 				'user_agent.original': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
@@ -62,11 +64,38 @@ describe('platform utilities', () => {
 
 			const result = getBasicPlatformInfo()
 			expect(result).toEqual({
+				'user_agent.is_automated': false,
+				'user_agent.is_bot': false,
 				'user_agent.language': 'en-GB',
 				'user_agent.mobile': undefined,
 				'user_agent.original': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
 				'user_agent.os.name': 'MacIntel',
 			})
+		})
+
+		it('should detect bot user agents', () => {
+			mockNavigator({
+				language: 'en-US',
+				platform: 'Win32',
+				userAgent: 'Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)',
+			})
+
+			const result = getBasicPlatformInfo()
+			expect(result['user_agent.is_bot']).toBe(true)
+			expect(result['user_agent.is_automated']).toBe(false)
+		})
+
+		it('should detect automated browsers via navigator.webdriver', () => {
+			mockNavigator({
+				language: 'en-US',
+				platform: 'Win32',
+				userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+				webdriver: true,
+			})
+
+			const result = getBasicPlatformInfo()
+			expect(result['user_agent.is_bot']).toBe(false)
+			expect(result['user_agent.is_automated']).toBe(true)
 		})
 	})
 
@@ -87,6 +116,8 @@ describe('platform utilities', () => {
 
 			const result = await getEnhancedPlatformInfo()
 			expect(result).toEqual({
+				'user_agent.is_automated': false,
+				'user_agent.is_bot': false,
 				'user_agent.language': 'en-US',
 				'user_agent.mobile': undefined,
 				'user_agent.original': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
@@ -112,6 +143,8 @@ describe('platform utilities', () => {
 
 			const result = await getEnhancedPlatformInfo()
 			expect(result).toEqual({
+				'user_agent.is_automated': false,
+				'user_agent.is_bot': false,
 				'user_agent.language': 'en-US',
 				'user_agent.mobile': undefined,
 				'user_agent.original': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36',
@@ -134,6 +167,8 @@ describe('platform utilities', () => {
 
 			const result = await getEnhancedPlatformInfo()
 			expect(result).toEqual({
+				'user_agent.is_automated': false,
+				'user_agent.is_bot': false,
 				'user_agent.language': 'en-US',
 				'user_agent.mobile': undefined,
 				'user_agent.original': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36',
@@ -154,6 +189,8 @@ describe('platform utilities', () => {
 
 			const result = await getEnhancedPlatformInfo()
 			expect(result).toEqual({
+				'user_agent.is_automated': false,
+				'user_agent.is_bot': false,
 				'user_agent.language': 'en-US',
 				'user_agent.mobile': undefined,
 				'user_agent.original': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',

--- a/packages/web/src/utils/platform.ts
+++ b/packages/web/src/utils/platform.ts
@@ -16,9 +16,13 @@
  *
  */
 
+import { isBot } from './is-bot'
+
 export function getBasicPlatformInfo() {
 	const userAgentData = navigator.userAgentData
 	return {
+		'user_agent.is_automated': !!navigator.webdriver,
+		'user_agent.is_bot': isBot(navigator.userAgent),
 		'user_agent.language': navigator.language,
 		'user_agent.mobile': userAgentData?.mobile,
 		'user_agent.original': navigator.userAgent,

--- a/packages/web/tests/utils/navigator.ts
+++ b/packages/web/tests/utils/navigator.ts
@@ -27,11 +27,13 @@ export function mockNavigator(config: {
 		mobile?: boolean
 		platform?: string
 	}
+	webdriver?: boolean
 }) {
 	const mockNav = {
 		language: config.language || 'en-US',
 		platform: config.platform || 'Win32',
 		userAgent: config.userAgent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+		webdriver: config.webdriver ?? false,
 		...(config.userAgentData && {
 			userAgentData: {
 				getHighEntropyValues: config.userAgentData.getHighEntropyValues || vi.fn().mockResolvedValue({}),


### PR DESCRIPTION
# Description

Add two new global span attributes to detect non-human traffic:

- `user_agent.is_bot`: leverages existing isBot() regex detection to flag bot/crawler user agents
- `user_agent.is_automated`: checks `navigator.webdriver` to detect browsers
    controlled by automation frameworks (Selenium, Puppeteer, Playwright)

Both attributes are set via getBasicPlatformInfo() and propagated to all spans as global attributes, enabling downstream filtering and analysis of synthetic vs real user traffic.


## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)


# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
