### PR TITLE
chore: add `splunk.rum.is_latest_tag` attribute

### DIFF
--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -181,17 +181,15 @@ const SplunkRumRecorder = {
 			}
 
 			if (isLatestTagUsed) {
-				const { exactVersion, majorVersion, minorVersion } = parseVersion(VERSION)
-				const cdnBase = 'https://cdn.signalfx.com/o11y-gdi-rum'
+				const { majorVersion } = parseVersion(VERSION)
+				const newCdnBase = 'https://cdn.observability.splunkcloud.com/o11y-gdi-rum'
 
 				log.warn(
-					'[Splunk]: You are using the "latest" version of splunk-otel-web-session-recorder.js. ' +
-						'This automatically pulls the newest released version, which may introduce breaking changes without notice. ' +
-						'This can cause unexpected behavior in production environments. ' +
-						'Please use a version lock strategy instead:\n' +
-						`  - Major version lock (recommended): ${cdnBase}/${majorVersion}/splunk-otel-web-session-recorder.js\n` +
-						`  - Minor version lock:               ${cdnBase}/${minorVersion}/splunk-otel-web-session-recorder.js\n` +
-						`  - Exact version lock:               ${cdnBase}/${exactVersion}/splunk-otel-web-session-recorder.js\n\n` +
+					'[Splunk]: The "latest" CDN tag is deprecated and will remain pinned to v2.5.x — it will not receive new features or major updates. ' +
+						'Please migrate to a versioned URL on the new CDN domain:\n' +
+						`  - Major version lock (recommended): ${newCdnBase}/${majorVersion}/splunk-otel-web-session-recorder.js\n\n` +
+						'The CDN domain is also changing from cdn.signalfx.com to cdn.observability.splunkcloud.com. ' +
+						'If your application uses a Content Security Policy (CSP), update your script-src directive to allow the new domain.\n\n' +
 						'See: https://quickdraw.splunk.com/redirect/?location=rum.browser.cdn&product=Observability&version=current',
 				)
 			}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -413,17 +413,15 @@ export const SplunkRum: SplunkOtelWebType = {
 			)
 
 			if (isLatestTagUsed) {
-				const { exactVersion, majorVersion, minorVersion } = parseVersion(VERSION)
-				const cdnBase = 'https://cdn.signalfx.com/o11y-gdi-rum'
+				const { majorVersion } = parseVersion(VERSION)
+				const newCdnBase = 'https://cdn.observability.splunkcloud.com/o11y-gdi-rum'
 
 				diag.warn(
-					'[Splunk]: You are using the "latest" version of splunk-otel-web.js. ' +
-						'This automatically pulls the newest released version, which may introduce breaking changes without notice. ' +
-						'This can cause unexpected behavior in production environments. ' +
-						'Please use a version lock strategy instead:\n' +
-						`  - Major version lock (recommended): ${cdnBase}/${majorVersion}/splunk-otel-web.js\n` +
-						`  - Minor version lock:               ${cdnBase}/${minorVersion}/splunk-otel-web.js\n` +
-						`  - Exact version lock:               ${cdnBase}/${exactVersion}/splunk-otel-web.js\n\n` +
+					'[Splunk]: The "latest" CDN tag is deprecated and will remain pinned to v2.5.x — it will not receive new features or major updates. ' +
+						'Please migrate to a versioned URL on the new CDN domain:\n' +
+						`  - Major version lock (recommended): ${newCdnBase}/${majorVersion}/splunk-otel-web.js\n\n` +
+						'The CDN domain is also changing from cdn.signalfx.com to cdn.observability.splunkcloud.com. ' +
+						'If your application uses a Content Security Policy (CSP), update your script-src directive to allow the new domain.\n\n' +
 						'See: https://quickdraw.splunk.com/redirect/?location=rum.browser.cdn&product=Observability&version=current',
 				)
 			}
@@ -601,6 +599,7 @@ export const SplunkRum: SplunkOtelWebType = {
 						? { 'deployment.environment': deploymentEnvironment, 'environment': deploymentEnvironment }
 						: {}),
 					...(version ? { 'app.version': version } : {}),
+					...(isLatestTagUsed ? { 'splunk.rum.is_latest_tag': true } : {}),
 					...processedOptions.globalAttributes,
 				},
 				processedOptions._experimental_discardDataAfterInactivity,


### PR DESCRIPTION
# Description

- Adds `splunk.rum.is_latest_tag: true` global attribute to every span when the agent is loaded  via the `latest` CDN tag, making it queryable in the backend
- Updates the deprecation warning in both `@splunk/otel-web` and `@splunk/otel-web-session-recorder`  to inform users that the `latest` tag will remain pinned to v2.5.x and will not receive new  features or major updates                                                                                                                                                                                               - Points users to the new CDN domain (`cdn.observability.splunkcloud.com`) and mentions CSP  directive changes needed before v3.0.0  

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
