### PR TITLE
chore: lock github actions to commit hash

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -4,7 +4,7 @@ runs:
     using: 'composite'
     steps:
         - name: Cache turbo build output
-          uses: actions/cache@v4.2.3
+          uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #5.0.5
           with:
               path: .turbo
               key: '${{ runner.os }}-turbo-${{ github.sha }}'
@@ -12,12 +12,12 @@ runs:
                   ${{ runner.os }}-turbo-
 
         - name: Install pnpm
-          uses: pnpm/action-setup@v4.1.0
+          uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 #5.0.0
           with:
               version: 10.26.1
 
         - name: Setup
-          uses: actions/setup-node@v4.3.0
+          uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #6.4.0
           with:
               node-version: 24.11.0
               registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -10,10 +10,10 @@ jobs:
         name: Link Checker
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v6.0.2
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
 
             - name: Link Checker
-              uses: lycheeverse/lychee-action@v2.8.0
+              uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411 #2.8.0
               with:
                   fail: true
                   args: "--verbose --no-progress './**/*.md' './**/*.html' --user-agent 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36'"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         permissions: read-all
         steps:
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
 
             - name: Setup
               uses: ./.github/actions/setup

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -17,7 +17,7 @@ jobs:
         steps:
             - name: 'CLA Assistant'
               if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
-              uses: cla-assistant/github-action@v2.6.1
+              uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 #2.6.1
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PERSONAL_ACCESS_TOKEN: ${{ secrets.PAT_CLATOOL }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
                 browser: [chromium, firefox, chrome, edge]
         steps:
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
 
             - name: Setup
               uses: ./.github/actions/setup
@@ -56,7 +56,7 @@ jobs:
         name: Unit & Integration Tests - ${{ matrix.browser }}
         steps:
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
 
             - name: Setup
               uses: ./.github/actions/setup
@@ -96,7 +96,7 @@ jobs:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
-              uses: actions/checkout@v6.0.2
+              uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #6.0.2
 
             - name: Setup
               uses: ./.github/actions/setup


### PR DESCRIPTION
# Description

Lock Github actions to commit hash instead of version.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

- Manual testing
