### PR TITLE
feat: add http.cache.hit attribute to resource spans

### DIFF
--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -93,6 +93,7 @@ test.describe('docload', () => {
 		if (browserName !== 'webkit') {
 			// Webkit does not support https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus
 			expect(Number.parseInt(scriptFetchSpans[0].tags['http.status_code'] as string)).toBe(200)
+			expect(scriptFetchSpans[0].tags['http.cache.hit']).toBe('false')
 		}
 
 		expect(brokenImageFetchSpans.length).toBeGreaterThanOrEqual(1)

--- a/packages/integration-tests/src/tests/resource-observer/resource-observer.spec.ts
+++ b/packages/integration-tests/src/tests/resource-observer/resource-observer.spec.ts
@@ -48,10 +48,12 @@ test.describe('resource observer', () => {
 		expect(imageBlackSpans[0].tags['http.url']).toBe(
 			'http://localhost:3000/resource-observer/assets/splunk-black.svg?delay=100',
 		)
+		expect(imageBlackSpans[0].tags['http.cache.hit']).toBe('false')
 
 		expect(scriptSpans).toHaveLength(1)
 		expect(scriptSpans[0].annotations.length).toBe(8)
 		expect(scriptSpans[0].tags['http.url']).toBe('http://localhost:3000/resource-observer/assets/test.js')
+		expect(scriptSpans[0].tags['http.cache.hit']).toBe('false')
 	})
 
 	test('resources can be ignored', async ({ recordPage }) => {
@@ -69,7 +71,7 @@ test.describe('resource observer', () => {
 		expect(scriptSpans).toHaveLength(0)
 	})
 
-	test('should create one span for cached resource', async ({ recordPage }) => {
+	test('should create one span for cached resource', async ({ browserName, recordPage }) => {
 		await recordPage.goTo('/resource-observer/resources-twice.ejs')
 
 		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'guard-span').length === 1)
@@ -79,6 +81,9 @@ test.describe('resource observer', () => {
 
 		expect(imageBlackSpans).toHaveLength(1)
 		expect(imageBlackSpans[0].tags['component']).toBe('document-load')
+		if (browserName !== 'webkit') {
+			expect(imageBlackSpans[0].tags['http.cache.hit']).toBe('false')
+		}
 	})
 
 	test('should create two spans for non cached resource', async ({ browserName, recordPage }) => {

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -32,6 +32,7 @@ import { SemanticAttributes, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-c
 import { SessionManager } from '../managers'
 import { captureTraceParentFromPerformanceEntries } from '../servertiming'
 import { SplunkOtelWebConfig } from '../types'
+import { isCacheHit } from '../utils/cache'
 
 export interface SplunkDocLoadInstrumentationConfig extends InstrumentationConfig {
 	ignoreUrls?: (string | RegExp)[]
@@ -146,6 +147,11 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 			const span = exposedSuper._startSpan(AttributeNames.RESOURCE_FETCH, PTN.FETCH_START, resource, parentSpan)
 			if (span) {
 				span.setAttribute(SEMATTRS_HTTP_URL, resource.name)
+				const cacheHitResult = isCacheHit(resource)
+				if (cacheHitResult !== undefined) {
+					span.setAttribute('http.cache.hit', cacheHitResult)
+				}
+
 				if (!exposedSuper.getConfig().ignoreNetworkEvents) {
 					addSpanNetworkEvents(span, resource)
 					if (typeof resource.responseStatus === 'number' && resource.responseStatus > 0) {

--- a/packages/web/src/instrumentations/splunk-post-doc-load-resource-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-post-doc-load-resource-instrumentation.ts
@@ -24,6 +24,7 @@ import { SemanticAttributes } from '@opentelemetry/semantic-conventions'
 
 import { SessionManager } from '../managers'
 import { SplunkOtelWebConfig } from '../types'
+import { isCacheHit } from '../utils/cache'
 import { VERSION } from '../version'
 
 export interface SplunkPostDocLoadResourceInstrumentationConfig extends InstrumentationConfig {
@@ -116,6 +117,11 @@ export class SplunkPostDocLoadResourceInstrumentation extends InstrumentationBas
 		span.setAttribute('component', MODULE_NAME)
 		span.setAttribute(SemanticAttributes.HTTP_URL, entry.name)
 		span.setAttribute(SemanticAttributes.HTTP_METHOD, 'GET')
+
+		const cacheHit = isCacheHit(entry)
+		if (cacheHit !== undefined) {
+			span.setAttribute('http.cache.hit', cacheHit)
+		}
 
 		addSpanNetworkEvents(span, entry)
 		//TODO look for server-timings? captureTraceParentFromPerformanceEntries(entry)

--- a/packages/web/src/utils/cache.test.ts
+++ b/packages/web/src/utils/cache.test.ts
@@ -1,0 +1,90 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { describe, expect, it } from 'vitest'
+
+import { isCacheHit } from './cache'
+
+function makeEntry(overrides: Partial<PerformanceResourceTiming> = {}): PerformanceResourceTiming {
+	return {
+		connectEnd: 0,
+		connectStart: 0,
+		contentType: '',
+		decodedBodySize: 1000,
+		deliveryType: '',
+		domainLookupEnd: 0,
+		domainLookupStart: 0,
+		duration: 0,
+		encodedBodySize: 1000,
+		entryType: 'resource',
+		fetchStart: 0,
+		firstInterimResponseStart: 0,
+		initiatorType: 'img',
+		name: 'https://example.com/image.png',
+		nextHopProtocol: 'h2',
+		redirectEnd: 0,
+		redirectStart: 0,
+		renderBlockingStatus: 'non-blocking',
+		requestStart: 0,
+		responseEnd: 0,
+		responseStart: 0,
+		responseStatus: 200,
+		secureConnectionStart: 0,
+		serverTiming: [],
+		startTime: 0,
+		toJSON: () => ({}),
+		transferSize: 5000,
+		workerStart: 0,
+		...overrides,
+	} as PerformanceResourceTiming
+}
+
+describe('isCacheHit', () => {
+	it('returns true for 304 responseStatus', () => {
+		const entry = makeEntry({ responseStatus: 304, transferSize: 5000 })
+		expect(isCacheHit(entry)).toBe(true)
+	})
+
+	it('returns true for local cache hit (transferSize=0, decodedBodySize>0)', () => {
+		const entry = makeEntry({ decodedBodySize: 1000, responseStatus: 200, transferSize: 0 })
+		expect(isCacheHit(entry)).toBe(true)
+	})
+
+	it('returns false when transferSize > 0 and responseStatus is not 304', () => {
+		const entry = makeEntry({ decodedBodySize: 1000, responseStatus: 200, transferSize: 5000 })
+		expect(isCacheHit(entry)).toBe(false)
+	})
+
+	it('returns undefined for cross-origin without Timing-Allow-Origin (transferSize=0, decodedBodySize=0)', () => {
+		const entry = makeEntry({ decodedBodySize: 0, responseStatus: 0, transferSize: 0 })
+		expect(isCacheHit(entry)).toBeUndefined()
+	})
+
+	it('returns undefined when transferSize is not available', () => {
+		const entry = makeEntry({ responseStatus: 200 })
+		Object.defineProperty(entry, 'transferSize', { value: undefined })
+		Object.defineProperty(entry, 'decodedBodySize', { value: undefined })
+		expect(isCacheHit(entry)).toBeUndefined()
+	})
+
+	it('returns true for 304 even when transferSize is unavailable', () => {
+		const entry = makeEntry({ responseStatus: 304 })
+		Object.defineProperty(entry, 'transferSize', { value: undefined })
+		Object.defineProperty(entry, 'decodedBodySize', { value: undefined })
+		expect(isCacheHit(entry)).toBe(true)
+	})
+})

--- a/packages/web/src/utils/cache.ts
+++ b/packages/web/src/utils/cache.ts
@@ -1,0 +1,48 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+/**
+ * Detects whether a resource was loaded from cache using PerformanceResourceTiming.
+ *
+ * Uses two complementary heuristics from the Resource Timing API:
+ * 1. responseStatus === 304 indicates a server-validated cache hit
+ *    https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus#checking_if_a_cache_was_hit
+ * 2. transferSize === 0 && decodedBodySize > 0 indicates a local/disk cache hit
+ *    (transferSize 0 alone could mean cross-origin with no Timing-Allow-Origin)
+ *    https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize#checking_if_a_cache_was_hit
+ *
+ * Returns undefined when cache status cannot be determined (e.g. cross-origin
+ * without Timing-Allow-Origin, or when the required fields are unavailable).
+ */
+export function isCacheHit(entry: PerformanceResourceTiming): boolean | undefined {
+	if (typeof entry.responseStatus === 'number' && entry.responseStatus === 304) {
+		return true
+	}
+
+	if (typeof entry.transferSize === 'number' && typeof entry.decodedBodySize === 'number') {
+		if (entry.transferSize === 0 && entry.decodedBodySize > 0) {
+			return true
+		}
+
+		if (entry.transferSize > 0) {
+			return false
+		}
+	}
+
+	return undefined
+}


### PR DESCRIPTION
# Description

- Adds `http.cache.hit` boolean attribute to resource fetch spans (both document-load and post-doc-load) using the PerformanceResourceTiming API
- Detects cache hits via two heuristics: `responseStatus === 304` (server-validated) and `transferSize === 0 && decodedBodySize > 0` (local/disk cache)
- Attribute is omitted when cache status cannot be determined (e.g. cross-origin without `Timing-Allow-Origin`)                                                                                                           


## References                                                                                                                                                                                                             
  - https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/responseStatus#checking_if_a_cache_was_hit                                                                                                   
  - https://developer.mozilla.org/en-US/docs/Web/API/PerformanceResourceTiming/transferSize#checking_if_a_cache_was_hit   

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
