### PR TITLE
feat: use protobuf for indexeddb session replay

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -29,19 +29,19 @@ module.exports = [
 	},
 
 	{
-		limit: '107 kB',
+		limit: '108 kB',
 		name: 'artifacts/splunk-otel-web-session-recorder.js',
 		path: './packages/session-recorder/dist/artifacts/splunk-otel-web-session-recorder.js',
 	},
 
 	{
-		limit: '112 kB',
+		limit: '117 kB',
 		name: 'session-recorder/cjs',
 		path: './packages/session-recorder/dist/cjs/index.js',
 	},
 
 	{
-		limit: '97 kB',
+		limit: '102 kB',
 		name: 'session-recorder/esm',
 		path: './packages/session-recorder/dist/esm/index.js',
 	},

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -247,6 +247,7 @@ const config = [
 			'unicorn/no-static-only-class': 'off',
 			'unicorn/no-this-assignment': 'off',
 			'unicorn/no-unnecessary-polyfills': 'off',
+			'unicorn/number-literal-case': 'off',
 			'unicorn/prefer-dom-node-remove': 'off',
 			'unicorn/prefer-dom-node-text-content': 'off',
 			'unicorn/prefer-global-this': 'off',

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"size-limit": "^12.1.0",
 		"socket.io": "^4.8.3",
 		"tsx": "^4.21.0",
-		"turbo": "^2.9.3",
+		"turbo": "^2.9.9",
 		"typescript": "^5.9.3",
 		"typescript-eslint": "^8.59.1",
 		"vitest": "^4.1.5",

--- a/packages/session-recorder/README.md
+++ b/packages/session-recorder/README.md
@@ -217,12 +217,12 @@ Choose a versioning strategy based on your needs:
 
 Controls how session replay data is persisted when upload requests fail:
 
-| Value            | Description                                                                                                                      |
-| ---------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `true`           | Default. Failed OTLP log exports are queued in localStorage (2 MB budget) and retried on next page load.                         |
-| `'localstorage'` | Same as `true`.                                                                                                                  |
-| `'indexeddb'`    | Uses the session replay script's built-in IndexedDB persistence. Segments are stored in IndexedDB and retried on next page load. |
-| `false`          | Disables persistence entirely.                                                                                                   |
+| Value            | Description                                                                                                                                                             |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `true`           | Default. Failed OTLP log exports are queued in localStorage (2 MB budget) and retried on next page load.                                                                |
+| `'localstorage'` | Same as `true`.                                                                                                                                                         |
+| `'indexeddb'`    | Uses the session replay script's built-in IndexedDB persistence and sends replay logs as OTLP/protobuf. Segments are stored in IndexedDB and retried on next page load. |
+| `false`          | Disables persistence entirely.                                                                                                                                          |
 
 ```typescript
 SplunkSessionRecorder.init({

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -20,9 +20,12 @@ import { Attributes, Span, trace, Tracer } from '@opentelemetry/api'
 import type { SplunkOtelWebType } from '@splunk/otel-web'
 import { JsonObject } from 'type-fest'
 
+import type { LogExporter } from './types'
+
 import { isRecorderLoadedViaLatestTag, isRecorderLoadedViaNextTag } from './detect-latest'
 import { log } from './log'
 import OTLPLogExporter from './otlp-log-exporter'
+import { OTLPProtoLogExporter } from './otlp-proto-log-exporter'
 import { Recorder, RecorderPublicConfig } from './session-replay'
 import { getGlobal, getSplunkRumVersion, isDebugMode, parseVersion } from './utils'
 import { VERSION } from './version'
@@ -92,8 +95,7 @@ const retryPendingSegments = (recorderInstance: Recorder, sessionId: string) => 
 				continue
 			}
 
-			const plainSegment = segment.toPlain()
-			recorderInstance.emitPendingSegment(plainSegment, () => {
+			recorderInstance.emitPendingSegment(segment, () => {
 				void recorderInstance.dismissPendingSegment(segmentId)
 			})
 		}
@@ -155,25 +157,34 @@ const SplunkRumRecorder = {
 		exportUrl: string
 		persistFailedReplayData: boolean | 'indexeddb' | 'localstorage'
 		sessionId: string
-	}): OTLPLogExporter {
-		const useLocalStorageQueue = persistFailedReplayData === true || persistFailedReplayData === 'localstorage'
-		return new OTLPLogExporter({
-			beaconUrl: exportUrl,
-			exportQueuedLogs,
-			getResourceAttributes() {
-				const newAttributes: JsonObject = {
-					...attributes,
-					'splunk.rumSessionId': sessionId,
-				}
-				if (anonymousUserId) {
-					newAttributes['user.anonymous_id'] = anonymousUserId
-				}
+	}): LogExporter {
+		const getResourceAttributes = () => {
+			const newAttributes: JsonObject = {
+				...attributes,
+				'splunk.rumSessionId': sessionId,
+			}
+			if (anonymousUserId) {
+				newAttributes['user.anonymous_id'] = anonymousUserId
+			}
 
-				return newAttributes
-			},
-			sessionId,
-			usePersistentExportQueue: useLocalStorageQueue,
-		})
+			return newAttributes
+		}
+
+		if (persistFailedReplayData === 'indexeddb') {
+			return new OTLPProtoLogExporter({
+				beaconUrl: exportUrl,
+				getResourceAttributes,
+			})
+		} else {
+			const useLocalStorageQueue = persistFailedReplayData === true || persistFailedReplayData === 'localstorage'
+			return new OTLPLogExporter({
+				beaconUrl: exportUrl,
+				exportQueuedLogs,
+				getResourceAttributes,
+				sessionId,
+				usePersistentExportQueue: useLocalStorageQueue,
+			})
+		}
 	},
 
 	deinit(): void {
@@ -328,6 +339,7 @@ const SplunkRumRecorder = {
 						initRecorderConfig,
 						persistSegments,
 						sessionId: currentState.id,
+						useBinarySegments: persistSegments,
 					})
 					recorder.start()
 
@@ -353,6 +365,7 @@ const SplunkRumRecorder = {
 					initRecorderConfig,
 					persistSegments,
 					sessionId,
+					useBinarySegments: persistSegments,
 				})
 				recorder.start()
 

--- a/packages/session-recorder/src/otlp-log-exporter.ts
+++ b/packages/session-recorder/src/otlp-log-exporter.ts
@@ -53,7 +53,11 @@ function isObject(value: JsonValue): value is JsonObject {
 	return !!value && typeof value === 'object' && !isArray(value)
 }
 
-function convertToAnyValue(value: JsonValue): IAnyValue {
+function convertToAnyValue(value: JsonValue | undefined): IAnyValue {
+	if (value === undefined || value === null) {
+		return {}
+	}
+
 	if (isObject(value)) {
 		return {
 			kvlistValue: {
@@ -118,8 +122,9 @@ export default class OTLPLogExporter {
 							logRecords: logs.map((logItem) => ({
 								attributes: convertToAnyValue(logItem.attributes || {}).kvlistValue
 									?.values as JsonArray,
-								// @ts-expect-error FIXME: `body` is not defined
-								body: convertToAnyValue(logItem.body) as JsonObject,
+								body: convertToAnyValue(
+									logItem.body instanceof Uint8Array ? undefined : logItem.body,
+								) as JsonObject,
 								timeUnixNano: logItem.timeUnixNano,
 							})),
 							scope: { name: 'splunk.rr-web', version: VERSION },

--- a/packages/session-recorder/src/otlp-proto-log-exporter.ts
+++ b/packages/session-recorder/src/otlp-proto-log-exporter.ts
@@ -1,0 +1,440 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { context } from '@opentelemetry/api'
+import { suppressTracing } from '@opentelemetry/core'
+import { gzipSync } from 'fflate'
+import type { JsonArray, JsonObject, JsonValue } from 'type-fest'
+
+import { apiFetch, ApiParams } from './api'
+import { log } from './log'
+import { compressAsync } from './session-replay/utils'
+import { IAnyValue, IKeyValue, Log, LogExporter } from './types'
+import { VERSION } from './version'
+
+interface OTLPProtoLogExporterConfig {
+	beaconUrl: string
+	getResourceAttributes: () => JsonObject
+	headers?: Record<string, string>
+}
+
+interface LogsData {
+	resourceLogs: ResourceLogs[]
+}
+
+interface ResourceLogs {
+	resource: Resource
+	scopeLogs: ScopeLogs[]
+}
+
+interface Resource {
+	attributes: IKeyValue[]
+}
+
+interface ScopeLogs {
+	logRecords: LogRecord[]
+	scope: InstrumentationScope
+}
+
+interface InstrumentationScope {
+	name: string
+	version: string
+}
+
+interface LogRecord {
+	attributes: IKeyValue[]
+	body: IAnyValue
+	timeUnixNano: number
+}
+
+const KEEPALIVE_MAX_LENGTH = 65_536
+const WIRE_TYPE_VARINT = 0
+const WIRE_TYPE_64_BIT = 1
+const WIRE_TYPE_LENGTH_DELIMITED = 2
+
+const defaultHeaders = {
+	'Content-Encoding': 'gzip',
+	'Content-Type': 'application/x-protobuf',
+}
+
+const textEncoder = new TextEncoder()
+
+class ProtoWriter {
+	private readonly data: number[] = []
+
+	bool(fieldNumber: number, value: boolean): void {
+		this.tag(fieldNumber, WIRE_TYPE_VARINT)
+		this.uint32(value ? 1 : 0)
+	}
+
+	bytes(fieldNumber: number, value: Uint8Array): void {
+		this.tag(fieldNumber, WIRE_TYPE_LENGTH_DELIMITED)
+		this.uint32(value.byteLength)
+		this.raw(value)
+	}
+
+	double(fieldNumber: number, value: number): void {
+		const buffer = new ArrayBuffer(8)
+		new DataView(buffer).setFloat64(0, value, true)
+
+		this.tag(fieldNumber, WIRE_TYPE_64_BIT)
+		this.raw(new Uint8Array(buffer))
+	}
+
+	finish(): Uint8Array<ArrayBuffer> {
+		return new Uint8Array(this.data)
+	}
+
+	fixed64(fieldNumber: number, value: number): void {
+		const safeValue = Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0
+		const low = safeValue >>> 0
+		const high = Math.floor(safeValue / 0x1_00_00_00_00) >>> 0
+
+		this.tag(fieldNumber, WIRE_TYPE_64_BIT)
+		this.uint32Byte(low)
+		this.uint32Byte(low >>> 8)
+		this.uint32Byte(low >>> 16)
+		this.uint32Byte(low >>> 24)
+		this.uint32Byte(high)
+		this.uint32Byte(high >>> 8)
+		this.uint32Byte(high >>> 16)
+		this.uint32Byte(high >>> 24)
+	}
+
+	int64(fieldNumber: number, value: number): void {
+		this.tag(fieldNumber, WIRE_TYPE_VARINT)
+		this.uint64(value)
+	}
+
+	message(fieldNumber: number, write: (writer: ProtoWriter) => void): void {
+		const nestedWriter = new ProtoWriter()
+		write(nestedWriter)
+		this.bytes(fieldNumber, nestedWriter.finish())
+	}
+
+	string(fieldNumber: number, value: string): void {
+		this.bytes(fieldNumber, textEncoder.encode(value))
+	}
+
+	uint32(value: number): void {
+		let currentValue = value >>> 0
+		while (currentValue > 0x7f) {
+			this.data.push((currentValue & 0x7f) | 0x80)
+			currentValue >>>= 7
+		}
+		this.data.push(currentValue)
+	}
+
+	private raw(value: Uint8Array): void {
+		for (const byte of value) {
+			this.data.push(byte)
+		}
+	}
+
+	private tag(fieldNumber: number, wireType: number): void {
+		this.uint32((fieldNumber << 3) | wireType)
+	}
+
+	private uint32Byte(value: number): void {
+		this.data.push(value & 0xff)
+	}
+
+	private uint64(value: number): void {
+		let currentValue = Number.isFinite(value) && value > 0 ? Math.trunc(value) : 0
+		while (currentValue > 0x7f) {
+			this.data.push((currentValue % 0x80) | 0x80)
+			currentValue = Math.floor(currentValue / 0x80)
+		}
+		this.data.push(currentValue)
+	}
+}
+
+function isArray(value: JsonValue): value is JsonArray {
+	return Array.isArray(value)
+}
+
+function isObject(value: JsonValue): value is JsonObject {
+	return !!value && typeof value === 'object' && !isArray(value)
+}
+
+function convertToAnyValue(value: JsonValue | Uint8Array | undefined): IAnyValue {
+	if (value === undefined || value === null) {
+		return {}
+	}
+
+	if (value instanceof Uint8Array) {
+		return {
+			bytesValue: value,
+		}
+	}
+
+	if (isObject(value)) {
+		return {
+			kvlistValue: {
+				values: Object.entries(value).map(([key, v]) => ({
+					key,
+					value: convertToAnyValue(v),
+				})),
+			},
+		}
+	}
+
+	if (isArray(value)) {
+		return {
+			arrayValue: {
+				values: value.map((v) => convertToAnyValue(v)),
+			},
+		}
+	}
+
+	if (typeof value === 'string') {
+		return {
+			stringValue: value,
+		}
+	}
+
+	if (typeof value === 'number') {
+		return {
+			doubleValue: value,
+		}
+	}
+
+	if (typeof value === 'boolean') {
+		return {
+			boolValue: value,
+		}
+	}
+
+	return {}
+}
+
+function writeLogsData(writer: ProtoWriter, logsData: LogsData): void {
+	for (const resourceLog of logsData.resourceLogs) {
+		writer.message(1, (resourceLogWriter) => writeResourceLogs(resourceLogWriter, resourceLog))
+	}
+}
+
+function writeResourceLogs(writer: ProtoWriter, resourceLog: ResourceLogs): void {
+	writer.message(1, (resourceWriter) => writeResource(resourceWriter, resourceLog.resource))
+
+	for (const scopeLog of resourceLog.scopeLogs) {
+		writer.message(2, (scopeLogWriter) => writeScopeLogs(scopeLogWriter, scopeLog))
+	}
+}
+
+function writeResource(writer: ProtoWriter, resource: Resource): void {
+	for (const attribute of resource.attributes) {
+		writer.message(1, (attributeWriter) => writeKeyValue(attributeWriter, attribute))
+	}
+}
+
+function writeScopeLogs(writer: ProtoWriter, scopeLog: ScopeLogs): void {
+	writer.message(1, (scopeWriter) => writeInstrumentationScope(scopeWriter, scopeLog.scope))
+
+	for (const logRecord of scopeLog.logRecords) {
+		writer.message(2, (logRecordWriter) => writeLogRecord(logRecordWriter, logRecord))
+	}
+}
+
+function writeInstrumentationScope(writer: ProtoWriter, scope: InstrumentationScope): void {
+	writer.string(1, scope.name)
+	writer.string(2, scope.version)
+}
+
+function writeLogRecord(writer: ProtoWriter, logRecord: LogRecord): void {
+	writer.fixed64(1, logRecord.timeUnixNano)
+	writer.message(5, (bodyWriter) => writeAnyValue(bodyWriter, logRecord.body))
+
+	for (const attribute of logRecord.attributes) {
+		writer.message(6, (attributeWriter) => writeKeyValue(attributeWriter, attribute))
+	}
+}
+
+function writeKeyValue(writer: ProtoWriter, keyValue: IKeyValue): void {
+	if (keyValue.key !== undefined && keyValue.key !== null) {
+		writer.string(1, keyValue.key)
+	}
+
+	if (keyValue.value) {
+		writer.message(2, (valueWriter) => writeAnyValue(valueWriter, keyValue.value as IAnyValue))
+	}
+}
+
+function writeAnyValue(writer: ProtoWriter, value: IAnyValue): void {
+	if (value.stringValue !== undefined && value.stringValue !== null) {
+		writer.string(1, value.stringValue)
+		return
+	}
+
+	if (value.boolValue !== undefined && value.boolValue !== null) {
+		writer.bool(2, value.boolValue)
+		return
+	}
+
+	if (value.intValue !== undefined && value.intValue !== null) {
+		writer.int64(3, value.intValue)
+		return
+	}
+
+	if (value.doubleValue !== undefined && value.doubleValue !== null) {
+		writer.double(4, value.doubleValue)
+		return
+	}
+
+	if (value.arrayValue) {
+		writer.message(5, (arrayWriter) => writeArrayValue(arrayWriter, value.arrayValue?.values ?? []))
+		return
+	}
+
+	if (value.kvlistValue) {
+		writer.message(6, (keyValueListWriter) =>
+			writeKeyValueList(keyValueListWriter, value.kvlistValue?.values ?? []),
+		)
+		return
+	}
+
+	if (value.bytesValue) {
+		writer.bytes(7, value.bytesValue)
+	}
+}
+
+function writeArrayValue(writer: ProtoWriter, values: IAnyValue[]): void {
+	for (const value of values) {
+		writer.message(1, (valueWriter) => writeAnyValue(valueWriter, value))
+	}
+}
+
+function writeKeyValueList(writer: ProtoWriter, values: IKeyValue[]): void {
+	for (const value of values) {
+		writer.message(1, (valueWriter) => writeKeyValue(valueWriter, value))
+	}
+}
+
+const onFetchError = (error: unknown) => {
+	log.error('Could not send protobuf data to BE - fetch', error)
+}
+
+export class OTLPProtoLogExporter implements LogExporter {
+	private readonly config: OTLPProtoLogExporterConfig
+
+	constructor(config: OTLPProtoLogExporterConfig) {
+		this.config = config
+	}
+
+	constructLogData(logs: Log[]): LogsData {
+		return {
+			resourceLogs: [
+				{
+					resource: {
+						attributes: convertToAnyValue(this.config.getResourceAttributes()).kvlistValue?.values ?? [],
+					},
+					scopeLogs: [
+						{
+							logRecords: logs.map((logItem) => ({
+								attributes: convertToAnyValue(logItem.attributes || {}).kvlistValue?.values ?? [],
+								body: convertToAnyValue(logItem.body),
+								timeUnixNano: logItem.timeUnixNano,
+							})),
+							scope: { name: 'splunk.rr-web', version: VERSION },
+						},
+					],
+				},
+			],
+		}
+	}
+
+	export(logs: Log[], onSuccess?: () => void): void {
+		if (logs.length === 0) {
+			return
+		}
+
+		const headers = this.config.headers ? Object.assign({}, defaultHeaders, this.config.headers) : defaultHeaders
+		const logsData = this.constructLogData(logs)
+		log.debug('OTLPProtoLogExporter: export', logsData)
+
+		const writer = new ProtoWriter()
+		writeLogsData(writer, logsData)
+
+		OTLPProtoLogExporter.sendDataToBackend(writer.finish(), this.config.beaconUrl, headers, onSuccess)
+	}
+
+	private static sendDataToBackend(
+		uint8ArrayData: Uint8Array<ArrayBuffer>,
+		endpoint: string,
+		headers: Record<string, string>,
+		onExportSuccess?: () => void,
+	): void {
+		const onFetchSuccess = () => {
+			onExportSuccess?.()
+		}
+
+		if (document.visibilityState === 'hidden') {
+			// TODO: https://github.com/101arrowz/fflate/issues/242
+			const compressedData = gzipSync(uint8ArrayData) as Uint8Array<ArrayBuffer>
+
+			// Use fetch with keepalive option instead of beacon.
+			// Fetch with keepalive option has limit of 64kB.
+			const shouldUseKeepAliveOption = compressedData.byteLength < KEEPALIVE_MAX_LENGTH
+			void sendByFetch(
+				endpoint,
+				{ body: compressedData, headers, keepalive: shouldUseKeepAliveOption },
+				onFetchSuccess,
+				onFetchError,
+			)
+		} else {
+			compressAsync(uint8ArrayData)
+				.then((compressedData) => {
+					void sendByFetch(endpoint, { body: compressedData, headers }, onFetchSuccess, onFetchError)
+				})
+				.catch((error) => {
+					log.error('Could not compress protobuf data', error)
+				})
+		}
+	}
+}
+
+const sendByFetchInternal = async (
+	endpoint: string,
+	fetchParams: Pick<ApiParams, 'headers' | 'keepalive' | 'body'>,
+	onSuccess: () => void,
+	onError: (error: unknown) => void,
+) => {
+	try {
+		await apiFetch(endpoint, {
+			abortPreviousRequest: false,
+			doNotConvert: true,
+			doNotRetryOnDocumentHidden: true,
+			method: 'POST',
+			retryCount: 5,
+			...fetchParams,
+		})
+
+		log.debug('Protobuf data sent by fetch', { keepalive: fetchParams.keepalive })
+		onSuccess()
+	} catch (error) {
+		onError(error)
+	}
+}
+
+const sendByFetch = (...args: Parameters<typeof sendByFetchInternal>) =>
+	new Promise((resolve, reject) => {
+		context.with(suppressTracing(context.active()), () => {
+			sendByFetchInternal(...args)
+				.then(resolve)
+				.catch(reject)
+		})
+	})

--- a/packages/session-recorder/src/session-replay/cdn-module-types.d.ts
+++ b/packages/session-recorder/src/session-replay/cdn-module-types.d.ts
@@ -49,7 +49,7 @@ declare module 'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/session-r
 
 	export interface Segment {
 		stats(): Stats
-		toBinary(params?: DeepPartial<Modifiers>): SessionReplayBinarySegment
+		toBinary(params?: DeepPartial<Modifiers> & { tryCompress?: boolean }): Promise<SessionReplayBinarySegment>
 		toPlain(params?: DeepPartial<Modifiers>): SessionReplayPlainSegment
 	}
 

--- a/packages/session-recorder/src/session-replay/cdn-module.ts
+++ b/packages/session-recorder/src/session-replay/cdn-module.ts
@@ -25,6 +25,7 @@ export {
 	type SensitivityRule,
 	type SensitivityRuleType,
 	SessionReplay,
+	type SessionReplayBinarySegment,
 	type SessionReplayConfig,
 	type SessionReplayPlainSegment,
 	type Stats,

--- a/packages/session-recorder/src/session-replay/recorder.ts
+++ b/packages/session-recorder/src/session-replay/recorder.ts
@@ -24,7 +24,14 @@ import { log } from '../log'
 import { isBoolean, isString } from '../type-guards'
 import { Log, LogExporter } from '../types'
 import { VERSION } from '../version'
-import { PendingSegmentData, Segment, SessionReplay, SessionReplayConfig } from './cdn-module'
+import {
+	PendingSegmentData,
+	Segment,
+	SessionReplay,
+	SessionReplayBinarySegment,
+	SessionReplayConfig,
+	SessionReplayPlainSegment,
+} from './cdn-module'
 import { getSplunkRecorderConfig } from './config'
 
 const MAX_CHUNK_SIZE = 4000 * 1024 // ~4000 KB
@@ -32,12 +39,18 @@ const MAX_CHUNK_SIZE = 4000 * 1024 // ~4000 KB
 const encoder = new TextEncoder()
 const decoder = new TextDecoder()
 
-function convert(body: JsonValue, timeUnixNano: number, attributes?: JsonObject): Log {
+function convert(body: JsonValue | Uint8Array, timeUnixNano: number, attributes?: JsonObject): Log {
 	return { attributes, body, timeUnixNano }
 }
 
-export interface RecorderEmitContext {
-	data: Record<string, unknown>
+type SessionReplaySegmentPayload = SessionReplayBinarySegment | SessionReplayPlainSegment
+
+function isBinarySegment(segment: SessionReplaySegmentPayload): segment is SessionReplayBinarySegment {
+	return segment.metadata.format === 'binary' || segment.metadata.format === 'binary-deflate'
+}
+
+interface SessionReplayEmitContext {
+	data: SessionReplaySegmentPayload
 	startTime: number
 }
 
@@ -60,18 +73,23 @@ export class Recorder {
 
 	private sessionReplay: SessionReplay
 
+	private readonly useBinarySegments: boolean
+
 	constructor({
 		exporter,
 		initRecorderConfig,
 		persistSegments,
 		sessionId,
+		useBinarySegments,
 	}: {
 		exporter: LogExporter
 		initRecorderConfig: Omit<SplunkRumRecorderConfig, 'realm' | 'recorder' | 'rumAccessToken' | 'beaconEndpoint'>
 		persistSegments: boolean
 		sessionId: string
+		useBinarySegments: boolean
 	}) {
 		this.exporter = exporter
+		this.useBinarySegments = useBinarySegments
 		this.config = {
 			originalFetch: (...args) =>
 				new Promise((resolve, reject) => {
@@ -136,14 +154,8 @@ export class Recorder {
 		return this.sessionReplay.dismissPendingSegment(segmentId)
 	}
 
-	emitPendingSegment(plainSegment: ReturnType<Segment['toPlain']>, onSuccess: () => void) {
-		this.onEmit(
-			{
-				data: plainSegment,
-				startTime: plainSegment.metadata.startUnixMs,
-			},
-			onSuccess,
-		)
+	emitPendingSegment(segment: Segment, onSuccess: () => void) {
+		this.emitSegmentPayload(this.getSegmentPayload(segment), onSuccess)
 	}
 
 	getPendingSegments(): Promise<PendingSegmentData[]> {
@@ -181,13 +193,31 @@ export class Recorder {
 		this.isStoppedManually = true
 	}
 
-	private onEmit = (emitContext: RecorderEmitContext, onSuccess?: () => void) => {
+	private emitSegmentPayload(segmentPayloadPromise: Promise<SessionReplaySegmentPayload>, onSuccess?: () => void) {
+		void this.resolveAndEmitSegmentPayload(segmentPayloadPromise, onSuccess).catch((error) => {
+			log.error('Could not emit session replay segment', error)
+		})
+	}
+
+	private async getSegmentPayload(segment: Segment): Promise<SessionReplaySegmentPayload> {
+		return this.useBinarySegments ? await segment.toBinary({ tryCompress: false }) : segment.toPlain()
+	}
+
+	private onEmit = async (emitContext: SessionReplayEmitContext, onSuccess?: () => void) => {
 		const time = Math.floor(emitContext.startTime)
 		const eventI = this.eventCounter
 
 		this.eventCounter += 1
 
-		const body = encoder.encode(JSON.stringify(emitContext.data.data))
+		const isBinary = isBinarySegment(emitContext.data)
+		let body: Uint8Array
+		if (isBinary) {
+			const segmentData = (emitContext.data as SessionReplayBinarySegment).data
+			body = new Uint8Array(await segmentData.arrayBuffer())
+		} else {
+			const segmentData = (emitContext.data as SessionReplayPlainSegment).data
+			body = encoder.encode(JSON.stringify(segmentData))
+		}
 
 		const totalC = Math.ceil(body.byteLength / MAX_CHUNK_SIZE)
 
@@ -203,7 +233,8 @@ export class Recorder {
 				'segmentMetadata': JSON.stringify(emitContext.data.metadata),
 			}
 
-			const logData = convert(decoder.decode(body.slice(start, end)), time, dataToConvert)
+			const bodyChunk = body.slice(start, end)
+			const logData = convert(isBinary ? bodyChunk : decoder.decode(bodyChunk), time, dataToConvert)
 
 			this.logCounter += 1
 
@@ -215,14 +246,21 @@ export class Recorder {
 
 	private onSegment = (segment: Segment, acknowledge: () => void) => {
 		log.debug('Session replay segment: ', segment)
-		const plainSegment = segment.toPlain()
+		this.emitSegmentPayload(this.getSegmentPayload(segment), acknowledge)
+	}
 
-		this.onEmit(
+	private async resolveAndEmitSegmentPayload(
+		segmentPayloadPromise: Promise<SessionReplaySegmentPayload>,
+		onSuccess?: () => void,
+	) {
+		const segmentPayload = await segmentPayloadPromise
+
+		await this.onEmit(
 			{
-				data: plainSegment,
-				startTime: plainSegment.metadata.startUnixMs,
+				data: segmentPayload,
+				startTime: segmentPayload.metadata.startUnixMs,
 			},
-			acknowledge,
+			onSuccess,
 		)
 	}
 

--- a/packages/session-recorder/src/types.ts
+++ b/packages/session-recorder/src/types.ts
@@ -20,7 +20,7 @@ import type { JsonObject, JsonValue } from 'type-fest'
 
 export interface Log {
 	attributes?: JsonObject
-	body?: JsonValue
+	body?: JsonValue | Uint8Array
 	timeUnixNano: number
 }
 

--- a/packages/web/src/session-based-sampler.ts
+++ b/packages/web/src/session-based-sampler.ts
@@ -60,7 +60,7 @@ export class SessionBasedSampler implements Sampler {
 		sampled = new AlwaysOnSampler(),
 	}: SessionBasedSamplerConfig = {}) {
 		this.ratio = this._normalize(ratio)
-		// eslint-disable-next-line unicorn/number-literal-case
+
 		this.upperBound = Math.floor(this.ratio * 0xff_ff_ff_ff)
 
 		this.sampled = sampled

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,8 +96,8 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
       turbo:
-        specifier: ^2.9.3
-        version: 2.9.3
+        specifier: ^2.9.9
+        version: 2.9.9
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -3091,33 +3091,33 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@turbo/darwin-64@2.9.3':
-    resolution: {integrity: sha512-P8foouaP+y/p+hhEGBoZpzMbpVvUMwPjDpcy6wN7EYfvvyISD1USuV27qWkczecihwuPJzQ1lDBuL8ERcavTyg==}
+  '@turbo/darwin-64@2.9.9':
+    resolution: {integrity: sha512-hTEiNu2ABZZOO1qbjnKASI8eF3BdOOzU6iKv5w5uGOK65DDMc10cS40N1kqM99YT0uSAGUwNu6GdFctRPeEeVA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.9.3':
-    resolution: {integrity: sha512-SIzEkvtNdzdI50FJDaIQ6kQGqgSSdFPcdn0wqmmONN6iGKjy6hsT+EH99GP65FsfV7DLZTh2NmtTIRl2kdoz5Q==}
+  '@turbo/darwin-arm64@2.9.9':
+    resolution: {integrity: sha512-MinO40EEcP5mJiTVpfjtEulsEBhVeryfq21QhYtJZ8hQJLHGgy459rcmDVAY8/JERe4dkVU4KW+zoLF22o01EA==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.9.3':
-    resolution: {integrity: sha512-pLRwFmcHHNBvsCySLS6OFabr/07kDT2pxEt/k6eBf/3asiVQZKJ7Rk88AafQx2aYA641qek4RsXvYO3JYpiBug==}
+  '@turbo/linux-64@2.9.9':
+    resolution: {integrity: sha512-7JNLw88Isk+gMlbsC8pulLDkrqe2B827ZsKFEHilb17AC6Xn/62pzH7afjY7fEU6Ayp4XP/vGhlRWOzqBvBvIQ==}
     cpu: [x64]
     os: [linux]
 
-  '@turbo/linux-arm64@2.9.3':
-    resolution: {integrity: sha512-gy6ApUroC2Nzv+qjGtE/uPNkhHAFU4c8God+zd5Aiv9L9uBgHlxVJpHT3XWl5xwlJZ2KWuMrlHTaS5kmNB+q1Q==}
+  '@turbo/linux-arm64@2.9.9':
+    resolution: {integrity: sha512-0pnXDwPw1rHii98JZPRg7SvsjIzy7jrhkwGU9Jy5fVYoMdYd3P2vbtLfII+OJ0Mm4Ar5yykdHDTz3RWiRI1o9g==}
     cpu: [arm64]
     os: [linux]
 
-  '@turbo/windows-64@2.9.3':
-    resolution: {integrity: sha512-d0YelTX6hAsB7kIEtGB3PzIzSfAg3yDoUlHwuwJc3adBXUsyUIs0YLG+1NNtuhcDOUGnWQeKUoJ2pGWvbpRj7w==}
+  '@turbo/windows-64@2.9.9':
+    resolution: {integrity: sha512-vjDQycz4gQVvIq4n2rPtiiIESwJlAc406qtkiZlqyL+fHZEd9SxYNlBIFYtc5cuMuwrk+sIKrhN7XvwjmvS9YQ==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.9.3':
-    resolution: {integrity: sha512-/08CwpKJl3oRY8nOlh2YgilZVJDHsr60XTNxRhuDeuFXONpUZ5X+Nv65izbG/xBew9qxcJFbDX9/sAmAX+ITcQ==}
+  '@turbo/windows-arm64@2.9.9':
+    resolution: {integrity: sha512-V6NiH43oCctepbOdQFp7UjqLyK8p6Tt824QA+G4TE+B1BBHu80A0W8OCL+H7uBJ3XZjAj/hvPDw3k3l65DoDGw==}
     cpu: [arm64]
     os: [win32]
 
@@ -7349,8 +7349,8 @@ packages:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
 
-  turbo@2.9.3:
-    resolution: {integrity: sha512-J/VUvsGRykPb9R8Kh8dHVBOqioDexLk9BhLCU/ZybRR+HN9UR3cURdazFvNgMDt9zPP8TF6K73Z+tplfmi0PqQ==}
+  turbo@2.9.9:
+    resolution: {integrity: sha512-3xfzXE/yTjhh0S5dIWlE+3E+J9A09REpLI1ZqVh2+HrNZoVzZn0pkvjiRgVK/Ev3PF9XnaTwCntTx+CADWXcyA==}
     hasBin: true
 
   type-check@0.4.0:
@@ -11224,22 +11224,22 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@turbo/darwin-64@2.9.3':
+  '@turbo/darwin-64@2.9.9':
     optional: true
 
-  '@turbo/darwin-arm64@2.9.3':
+  '@turbo/darwin-arm64@2.9.9':
     optional: true
 
-  '@turbo/linux-64@2.9.3':
+  '@turbo/linux-64@2.9.9':
     optional: true
 
-  '@turbo/linux-arm64@2.9.3':
+  '@turbo/linux-arm64@2.9.9':
     optional: true
 
-  '@turbo/windows-64@2.9.3':
+  '@turbo/windows-64@2.9.9':
     optional: true
 
-  '@turbo/windows-arm64@2.9.3':
+  '@turbo/windows-arm64@2.9.9':
     optional: true
 
   '@tybys/wasm-util@0.10.2':
@@ -13347,7 +13347,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.3
-      webpack: 5.106.2(webpack-cli@7.0.2)
+      webpack: 5.106.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack-cli@7.0.2)
 
   form-data@4.0.5:
     dependencies:
@@ -16208,7 +16208,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.9.3
-      webpack: 5.106.2(webpack-cli@7.0.2)
+      webpack: 5.106.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack-cli@7.0.2)
 
   ts-node@10.9.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(@types/node@25.5.0)(typescript@5.9.3):
     dependencies:
@@ -16245,14 +16245,14 @@ snapshots:
     dependencies:
       tslib: 1.14.1
 
-  turbo@2.9.3:
+  turbo@2.9.9:
     optionalDependencies:
-      '@turbo/darwin-64': 2.9.3
-      '@turbo/darwin-arm64': 2.9.3
-      '@turbo/linux-64': 2.9.3
-      '@turbo/linux-arm64': 2.9.3
-      '@turbo/windows-64': 2.9.3
-      '@turbo/windows-arm64': 2.9.3
+      '@turbo/darwin-64': 2.9.9
+      '@turbo/darwin-arm64': 2.9.9
+      '@turbo/linux-64': 2.9.9
+      '@turbo/linux-arm64': 2.9.9
+      '@turbo/windows-64': 2.9.9
+      '@turbo/windows-arm64': 2.9.9
 
   type-check@0.4.0:
     dependencies:
@@ -16489,7 +16489,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.106.2(webpack-cli@7.0.2)
+      webpack: 5.106.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack-cli@7.0.2)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-dev-server: 5.2.3(tslib@2.8.1)(webpack-cli@7.0.2)(webpack@5.106.2)
@@ -16512,7 +16512,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@7.0.2)
+      webpack: 5.106.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack-cli@7.0.2)
     transitivePeerDependencies:
       - tslib
 
@@ -16587,7 +16587,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.106.2)
       ws: 8.19.0
     optionalDependencies:
-      webpack: 5.106.2(webpack-cli@7.0.2)
+      webpack: 5.106.2(@swc/core@1.15.33(@swc/helpers@0.5.21))(webpack-cli@7.0.2)
       webpack-cli: 7.0.2(webpack-dev-server@5.2.3)(webpack@5.106.2)
     transitivePeerDependencies:
       - bufferutil

--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://turbo.build/schema.json",
+	"$schema": "https://v2-9-9.turborepo.dev/schema.json",
 	"globalDependencies": ["package.json", "pnpm-lock.yaml", "tsconfig.json", "eslint.config.js"],
 	"tasks": {
 		"//#typecheck:root": {


### PR DESCRIPTION
# Description

When `persistFailedReplayData: 'indexeddb'` is configured, session replay data is now exported as OTLP/protobuf instead of OTLP/JSON. This reduces the size of replay payloads sent to the backend, improving upload speed  and lowering bandwidth usage — especially on constrained or mobile connections.   

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)



# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
