### PR TITLE
chore: add `_experimental_captureBrowserDebugAttributes` option

### DIFF
--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -609,6 +609,11 @@ export const SplunkRum: SplunkOtelWebType = {
 				}
 			})
 
+			const platformInfoOptions = {
+				includeDebugInfo: processedOptions._experimental_captureBrowserDebugAttributes,
+			}
+			const basicPlatformInfo = getBasicPlatformInfo(platformInfoOptions)
+
 			this.attributesProcessor = new SpanAttributesProcessor(
 				this.sessionManager,
 				this.userManager,
@@ -619,6 +624,7 @@ export const SplunkRum: SplunkOtelWebType = {
 					...(version ? { 'app.version': version } : {}),
 					...(isLatestTagUsed ? { 'splunk.rum.is_latest_tag': true } : {}),
 					...processedOptions.globalAttributes,
+					...basicPlatformInfo,
 				},
 				processedOptions.discardDataAfterInactivity,
 				processedOptions.adjustSessionStartToTimeOrigin,
@@ -707,15 +713,11 @@ export const SplunkRum: SplunkOtelWebType = {
 
 			this.provider = provider
 
-			// Set basic platform attributes immediately
-			const basicPlatformInfo = getBasicPlatformInfo()
-			this.setGlobalAttributes(basicPlatformInfo)
-
 			inited = true
 			diag.info('SplunkRum.init() complete')
 
 			// Automatically update platform attributes with enhanced information in the background
-			void getEnhancedPlatformInfo().then((platformInfo) => {
+			void getEnhancedPlatformInfo(platformInfoOptions).then((platformInfo) => {
 				this.setGlobalAttributes(platformInfo)
 				diag.debug('[Splunk]: Enhanced platform attributes updated')
 			})

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -105,6 +105,21 @@ type SensitivityRule = {
 
 export interface SplunkOtelWebConfig {
 	/**
+	 * Experimental: Captures additional browser and device debug attributes and attaches
+	 * them to spans through global attributes.
+	 *
+	 * This includes browser-exposed navigator diagnostics such as hardware concurrency,
+	 * device memory, touch/language/vendor hints, network connection hints, storage
+	 * quota/usage, and high-entropy User-Agent Client Hints when available.
+	 *
+	 * These attributes can be high cardinality and should be enabled only while investigating
+	 * issues. The exact list of captured attributes can change without notice. No versioning
+	 * guarantees are given for this option.
+	 * @default false
+	 */
+	_experimental_captureBrowserDebugAttributes?: boolean
+
+	/**
 	 * Experimental: Data attribute names to capture from elements during user interactions.
 	 *
 	 * When specified, these data attributes will be collected from interacted elements and attached

--- a/packages/web/src/types/window.ts
+++ b/packages/web/src/types/window.ts
@@ -32,7 +32,23 @@ declare global {
 	}
 
 	interface Navigator {
+		readonly connection?: {
+			readonly downlink?: number
+			readonly effectiveType?: string
+			readonly rtt?: number
+			readonly saveData?: boolean
+			readonly type?: string
+		}
+
+		readonly deviceMemory?: number
+
+		readonly pdfViewerEnabled?: boolean
+
 		readonly userAgentData?: {
+			brands?: Array<{
+				brand: string
+				version: string
+			}>
 			mobile?: boolean
 			platform?: string
 			getHighEntropyValues(hints: string[]): Promise<
@@ -56,6 +72,14 @@ declare global {
 				  }
 				| undefined
 			>
+		}
+	}
+
+	interface Performance {
+		readonly memory?: {
+			readonly jsHeapSizeLimit?: number
+			readonly totalJSHeapSize?: number
+			readonly usedJSHeapSize?: number
 		}
 	}
 }

--- a/packages/web/src/utils/platform.test.ts
+++ b/packages/web/src/utils/platform.test.ts
@@ -97,6 +97,73 @@ describe('platform utilities', () => {
 			expect(result['user_agent.is_bot']).toBe(false)
 			expect(result['user_agent.is_automated']).toBe(true)
 		})
+
+		it('should include experimental browser debug attributes only when requested', () => {
+			mockNavigator({
+				connection: {
+					downlink: 10,
+					effectiveType: '4g',
+					rtt: 50,
+					saveData: false,
+				},
+				deviceMemory: 8,
+				hardwareConcurrency: 12,
+				languages: ['en-US', 'cs-CZ'],
+				maxTouchPoints: 5,
+				userAgentData: {
+					brands: [{ brand: 'Chromium', version: '123' }],
+					mobile: false,
+					platform: 'Windows',
+				},
+				vendor: 'Google Inc.',
+			})
+
+			expect(getBasicPlatformInfo()).not.toHaveProperty('browser.debug.hardware_concurrency')
+
+			const result = getBasicPlatformInfo({ includeDebugInfo: true })
+			expect(result).toMatchObject({
+				'browser.debug.connection.downlink': 10,
+				'browser.debug.connection.effective_type': '4g',
+				'browser.debug.connection.rtt': 50,
+				'browser.debug.connection.save_data': false,
+				'browser.debug.device_memory_gb': 8,
+				'browser.debug.hardware_concurrency': 12,
+				'browser.debug.languages': '["en-US","cs-CZ"]',
+				'browser.debug.max_touch_points': 5,
+				'browser.debug.ua.brands': '["Chromium/123"]',
+				'browser.debug.vendor': 'Google Inc.',
+			})
+			expect(result).not.toHaveProperty('browser.debug.feature.local_storage')
+			expect(result).not.toHaveProperty('browser.debug.viewport.width')
+		})
+
+		it('should skip failing experimental browser debug getters', () => {
+			mockNavigator({
+				connection: {
+					effectiveType: '4g',
+				},
+				deviceMemory: 8,
+				hardwareConcurrency: 12,
+			})
+
+			Object.defineProperty(navigator, 'connection', {
+				configurable: true,
+				get() {
+					throw new Error('connection unavailable')
+				},
+			})
+			Object.defineProperty(navigator, 'deviceMemory', {
+				configurable: true,
+				get() {
+					throw new Error('device memory unavailable')
+				},
+			})
+
+			const result = getBasicPlatformInfo({ includeDebugInfo: true })
+			expect(result).toHaveProperty('browser.debug.hardware_concurrency', 12)
+			expect(result).not.toHaveProperty('browser.debug.connection.effective_type')
+			expect(result).not.toHaveProperty('browser.debug.device_memory_gb')
+		})
 	})
 
 	describe('getEnhancedPlatformInfo', () => {
@@ -196,6 +263,65 @@ describe('platform utilities', () => {
 				'user_agent.original': 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15',
 				'user_agent.os.name': 'iPhone',
 			})
+		})
+
+		it('should include enhanced experimental browser debug attributes when requested', async () => {
+			const getHighEntropyValues = vi.fn().mockResolvedValue({
+				architecture: 'arm',
+				bitness: '64',
+				fullVersionList: [{ brand: 'Chromium', version: '123.0.1' }],
+				model: 'Pixel 8',
+				platformVersion: '15.0.0',
+				uaFullVersion: '123.0.1',
+				wow64: false,
+			})
+			const estimate = vi.fn().mockResolvedValue({
+				quota: 1000,
+				usage: 250,
+				usageDetails: {
+					caches: 150,
+					indexedDB: 100,
+				},
+			})
+
+			mockNavigator({
+				deviceMemory: 8,
+				hardwareConcurrency: 12,
+				storage: { estimate },
+				userAgentData: {
+					getHighEntropyValues,
+					mobile: false,
+					platform: 'Android',
+				},
+			})
+
+			const result = await getEnhancedPlatformInfo({ includeDebugInfo: true })
+			expect(result).toMatchObject({
+				'browser.debug.device_memory_gb': 8,
+				'browser.debug.hardware_concurrency': 12,
+				'browser.debug.storage.quota': 1000,
+				'browser.debug.storage.usage': 250,
+				'browser.debug.storage.usage_details.caches': 150,
+				'browser.debug.storage.usage_details.indexed_db': 100,
+				'browser.debug.ua.architecture': 'arm',
+				'browser.debug.ua.bitness': '64',
+				'browser.debug.ua.full_version': '123.0.1',
+				'browser.debug.ua.full_version_list': '["Chromium/123.0.1"]',
+				'browser.debug.ua.model': 'Pixel 8',
+				'browser.debug.ua.wow64': false,
+				'user_agent.os.name': 'Android',
+				'user_agent.os.version': '15.0.0',
+			})
+			expect(getHighEntropyValues).toHaveBeenCalledWith([
+				'architecture',
+				'bitness',
+				'fullVersionList',
+				'model',
+				'platformVersion',
+				'uaFullVersion',
+				'wow64',
+			])
+			expect(estimate).toHaveBeenCalled()
 		})
 	})
 })

--- a/packages/web/src/utils/platform.ts
+++ b/packages/web/src/utils/platform.ts
@@ -16,11 +16,130 @@
  *
  */
 
+import { Attributes } from '@opentelemetry/api'
+
+import { isValidAttributeValue } from './attributes'
 import { isBot } from './is-bot'
 
-export function getBasicPlatformInfo() {
+type PlatformInfoOptions = {
+	includeDebugInfo?: boolean
+}
+
+type BrandVersion = {
+	brand: string
+	version: string
+}
+
+type StorageEstimateWithDetails = StorageEstimate & {
+	usageDetails?: Record<string, number | undefined>
+}
+
+const HIGH_ENTROPY_HINTS = [
+	'architecture',
+	'bitness',
+	'fullVersionList',
+	'model',
+	'platformVersion',
+	'uaFullVersion',
+	'wow64',
+]
+
+function serializeDebugAttributeValue(value: unknown): unknown {
+	return Array.isArray(value) ? JSON.stringify(value) : value
+}
+
+function setDebugAttribute(attributes: Attributes, key: string, getValue: () => unknown): void {
+	let value: unknown
+
+	try {
+		value = serializeDebugAttributeValue(getValue())
+	} catch {
+		// Skip unavailable browser debug fields without dropping the whole attribute set.
+		return
+	}
+
+	if (isValidAttributeValue(value)) {
+		attributes[key] = value
+	}
+}
+
+function formatBrandVersions(brandVersions: BrandVersion[] | undefined): string[] | undefined {
+	return brandVersions?.map(({ brand, version }) => `${brand}/${version}`)
+}
+
+function toSnakeCase(value: string): string {
+	return value.replaceAll(/([a-z0-9])([A-Z])/g, '$1_$2').toLowerCase()
+}
+
+function getBasicBrowserDebugInfo(): Attributes {
+	const attributes: Attributes = {}
+
+	setDebugAttribute(attributes, 'browser.debug.hardware_concurrency', () => navigator.hardwareConcurrency)
+	setDebugAttribute(attributes, 'browser.debug.device_memory_gb', () => navigator.deviceMemory)
+	setDebugAttribute(attributes, 'browser.debug.max_touch_points', () => navigator.maxTouchPoints)
+	setDebugAttribute(attributes, 'browser.debug.cookie_enabled', () => navigator.cookieEnabled)
+	setDebugAttribute(attributes, 'browser.debug.do_not_track', () => navigator.doNotTrack)
+	setDebugAttribute(attributes, 'browser.debug.languages', () =>
+		navigator.languages ? [...navigator.languages] : undefined,
+	)
+	setDebugAttribute(attributes, 'browser.debug.vendor', () => navigator.vendor)
+	setDebugAttribute(attributes, 'browser.debug.pdf_viewer_enabled', () => navigator.pdfViewerEnabled)
+	setDebugAttribute(attributes, 'browser.debug.online', () => navigator.onLine)
+
+	setDebugAttribute(attributes, 'browser.debug.connection.type', () => navigator.connection?.type)
+	setDebugAttribute(attributes, 'browser.debug.connection.effective_type', () => navigator.connection?.effectiveType)
+	setDebugAttribute(attributes, 'browser.debug.connection.downlink', () => navigator.connection?.downlink)
+	setDebugAttribute(attributes, 'browser.debug.connection.rtt', () => navigator.connection?.rtt)
+	setDebugAttribute(attributes, 'browser.debug.connection.save_data', () => navigator.connection?.saveData)
+
+	setDebugAttribute(attributes, 'browser.debug.ua.brands', () => formatBrandVersions(navigator.userAgentData?.brands))
+
+	return attributes
+}
+
+function getHighEntropyBrowserDebugInfo(
+	highEntropy: Awaited<ReturnType<NonNullable<Navigator['userAgentData']>['getHighEntropyValues']>>,
+): Attributes {
+	const attributes: Attributes = {}
+
+	setDebugAttribute(attributes, 'browser.debug.ua.architecture', () => highEntropy?.architecture)
+	setDebugAttribute(attributes, 'browser.debug.ua.bitness', () => highEntropy?.bitness)
+	setDebugAttribute(attributes, 'browser.debug.ua.full_version', () => highEntropy?.uaFullVersion)
+	setDebugAttribute(attributes, 'browser.debug.ua.full_version_list', () =>
+		formatBrandVersions(highEntropy?.fullVersionList),
+	)
+	setDebugAttribute(attributes, 'browser.debug.ua.model', () => highEntropy?.model)
+	setDebugAttribute(attributes, 'browser.debug.ua.wow64', () => highEntropy?.wow64)
+
+	return attributes
+}
+
+async function getStorageDebugInfo(): Promise<Attributes> {
+	const attributes: Attributes = {}
+
+	try {
+		if (!navigator.storage?.estimate) {
+			return attributes
+		}
+
+		const estimate = (await navigator.storage.estimate()) as StorageEstimateWithDetails
+
+		setDebugAttribute(attributes, 'browser.debug.storage.quota', () => estimate.quota)
+		setDebugAttribute(attributes, 'browser.debug.storage.usage', () => estimate.usage)
+
+		for (const [key, value] of Object.entries(estimate.usageDetails ?? {})) {
+			setDebugAttribute(attributes, `browser.debug.storage.usage_details.${toSnakeCase(key)}`, () => value)
+		}
+	} catch (error) {
+		console.warn('[Splunk]: Could not get browser storage debug information:', error)
+	}
+
+	return attributes
+}
+
+export function getBasicPlatformInfo(options: PlatformInfoOptions = {}) {
 	const userAgentData = navigator.userAgentData
-	return {
+	const basicInfo = {
 		'user_agent.is_automated': !!navigator.webdriver,
 		'user_agent.is_bot': isBot(navigator.userAgent),
 		'user_agent.language': navigator.language,
@@ -28,34 +147,57 @@ export function getBasicPlatformInfo() {
 		'user_agent.original': navigator.userAgent,
 		'user_agent.os.name': userAgentData?.platform || navigator.platform,
 	}
+
+	if (!options.includeDebugInfo) {
+		return basicInfo
+	}
+
+	return {
+		...basicInfo,
+		...getBasicBrowserDebugInfo(),
+	}
 }
 
 /**
  * Gets enhanced platform information using User Agent Client Hints API
  * Falls back to basic info if the API is not available
  */
-export async function getEnhancedPlatformInfo() {
-	const basicInfo = getBasicPlatformInfo()
+export async function getEnhancedPlatformInfo(options: PlatformInfoOptions = {}) {
+	const basicInfo = getBasicPlatformInfo(options)
+	const storageDebugInfo = options.includeDebugInfo ? await getStorageDebugInfo() : {}
 
 	// Check if User Agent Client Hints API is available
 	if (!navigator.userAgentData?.getHighEntropyValues) {
-		return basicInfo
+		return {
+			...basicInfo,
+			...storageDebugInfo,
+		}
 	}
 
 	try {
-		const highEntropy = await navigator.userAgentData.getHighEntropyValues(['platformVersion'])
+		const highEntropy = await navigator.userAgentData.getHighEntropyValues(
+			options.includeDebugInfo ? HIGH_ENTROPY_HINTS : ['platformVersion'],
+		)
+		const enhancedInfo = {
+			...basicInfo,
+			...storageDebugInfo,
+			...(options.includeDebugInfo ? getHighEntropyBrowserDebugInfo(highEntropy) : {}),
+		}
 
 		if (highEntropy?.platformVersion) {
 			return {
-				...basicInfo,
+				...enhancedInfo,
 				'user_agent.os.version': highEntropy.platformVersion,
 			}
 		}
 
-		return basicInfo
+		return enhancedInfo
 	} catch (error) {
 		// If high entropy values fail (e.g., user denied permission), return basic info
 		console.warn('[Splunk]: Could not get enhanced platform information:', error)
-		return basicInfo
+		return {
+			...basicInfo,
+			...storageDebugInfo,
+		}
 	}
 }

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -868,6 +868,42 @@ describe('platform attributes', () => {
 		expectDefined(testSpan)
 		expect(testSpan.attributes['user_agent.os.name']).toBe('Windows')
 	})
+
+	it('should add experimental browser debug attributes to spans when enabled', async () => {
+		mockNavigator({
+			connection: {
+				effectiveType: '4g',
+				rtt: 25,
+			},
+			deviceMemory: 16,
+			hardwareConcurrency: 8,
+			platform: 'Win32',
+			userAgentData: {
+				platform: 'Windows',
+			},
+		})
+
+		SplunkRum.init({
+			_experimental_captureBrowserDebugAttributes: true,
+			applicationName: 'test-app',
+			beaconEndpoint: 'https://127.0.0.1:9999/test',
+			rumAccessToken: undefined,
+			spanProcessors: [capturer],
+		})
+
+		const tracer = getTracer('test')
+		const span = tracer.startSpan('test-span')
+		span.end()
+
+		await new Promise((resolve) => setTimeout(resolve, 100))
+
+		const testSpan = capturer.spans.find((s) => s.name === 'test-span')
+		expectDefined(testSpan)
+		expect(testSpan.attributes['browser.debug.hardware_concurrency']).toBe(8)
+		expect(testSpan.attributes['browser.debug.device_memory_gb']).toBe(16)
+		expect(testSpan.attributes['browser.debug.connection.effective_type']).toBe('4g')
+		expect(testSpan.attributes['browser.debug.connection.rtt']).toBe(25)
+	})
 })
 
 describe('can produce click events', () => {

--- a/packages/web/tests/utils/navigator.ts
+++ b/packages/web/tests/utils/navigator.ts
@@ -19,23 +19,54 @@
 import { vi } from 'vitest'
 
 export function mockNavigator(config: {
+	connection?: {
+		downlink?: number
+		effectiveType?: string
+		rtt?: number
+		saveData?: boolean
+		type?: string
+	}
+	cookieEnabled?: boolean
+	deviceMemory?: number
+	doNotTrack?: string
+	hardwareConcurrency?: number
 	language?: string
+	languages?: string[]
+	maxTouchPoints?: number
 	platform?: string
+	storage?: {
+		estimate?: () => Promise<StorageEstimate>
+	}
 	userAgent?: string
 	userAgentData?: {
+		brands?: Array<{
+			brand: string
+			version: string
+		}>
 		getHighEntropyValues?: any
 		mobile?: boolean
 		platform?: string
 	}
+	vendor?: string
 	webdriver?: boolean
 }) {
 	const mockNav = {
+		connection: config.connection,
+		cookieEnabled: config.cookieEnabled ?? true,
+		deviceMemory: config.deviceMemory,
+		doNotTrack: config.doNotTrack,
+		hardwareConcurrency: config.hardwareConcurrency,
 		language: config.language || 'en-US',
+		languages: config.languages,
+		maxTouchPoints: config.maxTouchPoints,
 		platform: config.platform || 'Win32',
+		storage: config.storage,
 		userAgent: config.userAgent || 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
+		vendor: config.vendor,
 		webdriver: config.webdriver ?? false,
 		...(config.userAgentData && {
 			userAgentData: {
+				brands: config.userAgentData.brands,
 				getHighEntropyValues: config.userAgentData.getHighEntropyValues || vi.fn().mockResolvedValue({}),
 				mobile: config.userAgentData.mobile,
 				platform: config.userAgentData.platform || config.platform || 'Windows',


### PR DESCRIPTION
# Description


Adds an experimental `_experimental_captureBrowserDebugAttributes` flag that attaches additional browser and device diagnostics to spans through global attributes.

  When enabled, the agent collects browser-exposed debug context such as:

  - hardware concurrency and device memory
  - viewport, window, screen, orientation, and device pixel ratio
  - network connection hints such as effective type, downlink, RTT, and save-data
  - JS heap memory when exposed by the browser
  - storage quota, usage, and usage details when available
  - User-Agent Client Hints, including brands, architecture, bitness, full version list, model, platform version, and WOW64

  This flag is experimental. The exact list of captured attributes may change without notice.


## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)


# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
