### PR TITLE
feat: enable experimental TTFB and FCP webvitals, and additional webvitals attributes

### DIFF
--- a/packages/integration-tests/src/tests/webvitals/webvitals-additional-metrics.ejs
+++ b/packages/integration-tests/src/tests/webvitals/webvitals-additional-metrics.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Webvitals additional metrics</title>
+
+	<%- renderAgent({debug: true, instrumentations: {webvitals: {_experimental_attribution: true, _experimental_fcp: true, _experimental_ttfb: true}}}) %>
+
+	<style>
+		#container {
+			height: 200px;
+			width: 400px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Webvitals additional metrics</h1>
+
+	<a href="javascript:clicky()" id="clicky">Click me</a>
+
+	<div id="container">Don't shift me : (</div>
+	<script>
+		let id = 1;
+		const container = document.getElementById('container');
+		function clicky() {
+			const p = document.createElement('p');
+			p.setAttribute('id', 'p'+id);
+			id++;
+			p.innerText = 'Very long paragraph to force a visual change.  '.repeat(30);
+			container.insertBefore(p, container.firstChild);
+		}
+		window.addEventListener('load', clicky);
+	</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/webvitals/webvitals-attribution.ejs
+++ b/packages/integration-tests/src/tests/webvitals/webvitals-attribution.ejs
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Webvitals attribution</title>
+
+	<%- renderAgent({debug: true, instrumentations: {webvitals: {_experimental_attribution: true}}}) %>
+
+	<style>
+		#container {
+			height: 200px;
+			width: 400px;
+		}
+	</style>
+</head>
+<body>
+	<h1>Webvitals attribution</h1>
+
+	<a href="javascript:clicky()" id="clicky">Click me</a>
+
+	<div id="container">Don't shift me : (</div>
+	<script>
+		let id = 1;
+		const container = document.getElementById('container');
+		function clicky() {
+			const p = document.createElement('p');
+			p.setAttribute('id', 'p'+id);
+			id++;
+			p.innerText = 'Very long paragraph to force a visual change.  '.repeat(30);
+			container.insertBefore(p, container.firstChild);
+		}
+		window.addEventListener('load', clicky);
+	</script>
+</body>
+</html>

--- a/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
+++ b/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
@@ -88,6 +88,126 @@ test.describe('web vitals', () => {
 		expect(webvitalsSpan.tags['location.href']).toBe(docLoadUrl)
 	})
 
+	test('webvitals - attribution attributes are NOT emitted by default', async ({ browserName, recordPage }) => {
+		if (browserName === 'webkit' || browserName === 'firefox') {
+			test.skip()
+		}
+
+		await recordPage.goTo('/webvitals/webvitals.ejs')
+
+		await recordPage.locator('#clicky').click()
+		await expect(recordPage.locator('#p2')).toBeAttached()
+
+		await recordPage.changeVisibilityInTab('hidden')
+		await recordPage.waitForTimeoutAndFlushData(1000)
+
+		const webvitalsSpans = recordPage.receivedSpans.filter((span) => span.name === 'webvitals')
+		expect(webvitalsSpans.length).toBeGreaterThan(0)
+
+		for (const span of webvitalsSpans) {
+			expect(span.tags['webvitals.name']).toBeUndefined()
+			expect(span.tags['webvitals.rating']).toBeUndefined()
+			expect(span.tags['webvitals.navigation_type']).toBeUndefined()
+		}
+
+		const fcp = recordPage.receivedSpans.filter((span) => span.tags.fcp !== undefined)
+		const ttfb = recordPage.receivedSpans.filter((span) => span.tags.ttfb !== undefined)
+		expect(fcp).toHaveLength(0)
+		expect(ttfb).toHaveLength(0)
+
+		expect(recordPage.receivedErrorSpans).toHaveLength(0)
+	})
+
+	test('webvitals - attribution attributes are emitted when _experimental_attribution is enabled', async ({
+		browserName,
+		recordPage,
+	}) => {
+		if (browserName === 'webkit' || browserName === 'firefox') {
+			test.skip()
+		}
+
+		await recordPage.goTo('/webvitals/webvitals-attribution.ejs')
+
+		await recordPage.locator('#clicky').click()
+		await expect(recordPage.locator('#p2')).toBeAttached()
+
+		await recordPage.changeVisibilityInTab('hidden')
+		await recordPage.waitForTimeoutAndFlushData(1000)
+
+		const lcpSpan = recordPage.receivedSpans.find((span) => span.tags.lcp !== undefined)
+		expectDefined(lcpSpan)
+		expect(lcpSpan.name).toBe('webvitals')
+		expect(lcpSpan.tags['webvitals.name']).toBe('LCP')
+		expect(lcpSpan.tags['webvitals.rating']).toBeDefined()
+		expect(lcpSpan.tags['webvitals.navigation_type']).toBeDefined()
+		expect(lcpSpan.tags['lcp.element_render_delay']).toBeDefined()
+		expect(lcpSpan.tags['lcp.resource_load_delay']).toBeDefined()
+		expect(lcpSpan.tags['lcp.resource_load_duration']).toBeDefined()
+		expect(lcpSpan.tags['lcp.time_to_first_byte']).toBeDefined()
+		expect(lcpSpan.tags['lcp.target']).toBeDefined()
+		expect(lcpSpan.tags['lcp.url']).toBeDefined()
+
+		const clsSpan = recordPage.receivedSpans.find((span) => span.tags.cls !== undefined)
+		expectDefined(clsSpan)
+		expect(clsSpan.name).toBe('webvitals')
+		expect(clsSpan.tags['webvitals.name']).toBe('CLS')
+		expect(clsSpan.tags['cls.largest_shift_target']).toBeDefined()
+		expect(clsSpan.tags['cls.largest_shift_time']).toBeDefined()
+		expect(clsSpan.tags['cls.largest_shift_value']).toBeDefined()
+		expect(clsSpan.tags['cls.load_state']).toBeDefined()
+
+		const inpSpan = recordPage.receivedSpans.find((span) => span.tags.inp !== undefined)
+		if (inpSpan) {
+			expect(inpSpan.name).toBe('webvitals')
+			expect(inpSpan.tags['webvitals.name']).toBe('INP')
+			expect(inpSpan.tags['inp.input_delay']).toBeDefined()
+			expect(inpSpan.tags['inp.processing_duration']).toBeDefined()
+			expect(inpSpan.tags['inp.presentation_delay']).toBeDefined()
+			expect(inpSpan.tags['inp.interaction_target']).toBeDefined()
+			expect(inpSpan.tags['inp.interaction_type']).toBeDefined()
+			expect(inpSpan.tags['inp.load_state']).toBeDefined()
+		}
+
+		expect(recordPage.receivedErrorSpans).toHaveLength(0)
+	})
+
+	test('webvitals - FCP and TTFB spans are emitted when _experimental_fcp / _experimental_ttfb are enabled', async ({
+		browserName,
+		recordPage,
+	}) => {
+		if (browserName === 'webkit' || browserName === 'firefox') {
+			test.skip()
+		}
+
+		await recordPage.goTo('/webvitals/webvitals-additional-metrics.ejs')
+
+		await recordPage.locator('#clicky').click()
+		await expect(recordPage.locator('#p2')).toBeAttached()
+
+		await recordPage.changeVisibilityInTab('hidden')
+		await recordPage.waitForTimeoutAndFlushData(1000)
+
+		const fcpSpan = recordPage.receivedSpans.find((span) => span.tags.fcp !== undefined)
+		expectDefined(fcpSpan)
+		expect(fcpSpan.name).toBe('webvitals')
+		expect(fcpSpan.tags['webvitals.name']).toBe('FCP')
+		expect(fcpSpan.tags['fcp.first_byte_to_fcp']).toBeDefined()
+		expect(fcpSpan.tags['fcp.time_to_first_byte']).toBeDefined()
+		expect(fcpSpan.tags['fcp.load_state']).toBeDefined()
+
+		const ttfbSpan = recordPage.receivedSpans.find((span) => span.tags.ttfb !== undefined)
+		expectDefined(ttfbSpan)
+		expect(ttfbSpan.name).toBe('webvitals')
+		expect(ttfbSpan.tags['webvitals.name']).toBe('TTFB')
+		expect(ttfbSpan.tags['ttfb.cache_duration']).toBeDefined()
+		expect(ttfbSpan.tags['ttfb.connection_duration']).toBeDefined()
+		expect(ttfbSpan.tags['ttfb.dns_duration']).toBeDefined()
+		expect(ttfbSpan.tags['ttfb.request_duration']).toBeDefined()
+		expect(ttfbSpan.tags['ttfb.waiting_duration']).toBeDefined()
+
+		expect(recordPage.receivedErrorSpans).toHaveLength(0)
+	})
+
 	test('webvitals - specific metrics disabled', async ({ browserName, recordPage }) => {
 		if (browserName === 'webkit' || browserName === 'firefox') {
 			test.skip()

--- a/packages/web/src/instrumentations/splunk-webvitals-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-webvitals-instrumentation.ts
@@ -16,11 +16,25 @@
  *
  */
 
-import { HrTime } from '@opentelemetry/api'
+import { Attributes, HrTime } from '@opentelemetry/api'
 import { addHrTimes, hrTimeToMilliseconds, millisToHrTime } from '@opentelemetry/core'
 import { InstrumentationBase, InstrumentationConfig } from '@opentelemetry/instrumentation'
 import { ReadableSpan } from '@opentelemetry/sdk-trace-base'
-import { Metric, onCLS, onINP, onLCP, ReportOpts } from 'web-vitals'
+import {
+	CLSMetricWithAttribution,
+	FCPMetricWithAttribution,
+	INPMetricWithAttribution,
+	LCPMetricWithAttribution,
+	Metric,
+	MetricWithAttribution,
+	onCLS,
+	onFCP,
+	onINP,
+	onLCP,
+	onTTFB,
+	ReportOpts,
+	TTFBMetricWithAttribution,
+} from 'web-vitals/attribution'
 
 import { SessionManager } from '../managers'
 import { SplunkOtelWebConfig } from '../types'
@@ -29,6 +43,41 @@ import { VERSION } from '../version'
 const MODULE_NAME = 'splunk-webvitals'
 
 export interface SplunkWebVitalsInstrumentationConfig extends InstrumentationConfig {
+	/**
+	 * Experimental: when enabled, web vitals spans gain attribution attributes
+	 * describing the cause of the metric value (e.g., target element selector
+	 * for LCP/CLS, timing breakdowns for INP) plus common `webvitals.*` attributes
+	 * (name, rating, navigation type) on every web vitals span.
+	 *
+	 * Expected to become the default in a future minor release; the option
+	 * will then be deprecated.
+	 *
+	 * @default false
+	 * @experimental
+	 */
+	_experimental_attribution?: boolean
+	/**
+	 * Experimental: when set, First Contentful Paint (FCP) is reported as a
+	 * `webvitals` span. Pass `true` (or a `ReportOpts` object) to enable.
+	 *
+	 * Expected to become the default in a future minor release; the option
+	 * will then be renamed to `fcp` (mirroring the `cls`/`inp`/`lcp` shape).
+	 *
+	 * @default false
+	 * @experimental
+	 */
+	_experimental_fcp?: boolean | ReportOpts
+	/**
+	 * Experimental: when set, Time to First Byte (TTFB) is reported as a
+	 * `webvitals` span. Pass `true` (or a `ReportOpts` object) to enable.
+	 *
+	 * Expected to become the default in a future minor release; the option
+	 * will then be renamed to `ttfb` (mirroring the `cls`/`inp`/`lcp` shape).
+	 *
+	 * @default false
+	 * @experimental
+	 */
+	_experimental_ttfb?: boolean | ReportOpts
 	/**
 	 * If true, the webvitals spans will have their start time aligned with the document load span,
 	 * and will inherit the URL attributes from the document load span if available.
@@ -112,11 +161,29 @@ export class SplunkWebVitalsInstrumentation extends InstrumentationBase<SplunkWe
 				typeof this._config.inp === 'object' ? this._config.inp : undefined,
 			)
 		}
+
+		if (this._config._experimental_fcp) {
+			onFCP(
+				(metric) => {
+					void this.reportMetric('fcp', metric)
+				},
+				typeof this._config._experimental_fcp === 'object' ? this._config._experimental_fcp : undefined,
+			)
+		}
+
+		if (this._config._experimental_ttfb) {
+			onTTFB(
+				(metric) => {
+					void this.reportMetric('ttfb', metric)
+				},
+				typeof this._config._experimental_ttfb === 'object' ? this._config._experimental_ttfb : undefined,
+			)
+		}
 	}
 
 	init(): void {}
 
-	private async reportMetric(name: string, metric: Metric): Promise<void> {
+	private async reportMetric(name: string, metric: MetricWithAttribution): Promise<void> {
 		if (!this.isRecording) {
 			return
 		}
@@ -161,10 +228,100 @@ export class SplunkWebVitalsInstrumentation extends InstrumentationBase<SplunkWe
 		}
 
 		span.setAttribute(name, value)
+		if (this._config._experimental_attribution) {
+			span.setAttributes(buildCommonAttributes(metric))
+			span.setAttributes(buildAttributionAttributes(name, metric))
+		}
+
 		span.end(endTime)
 	}
 
 	private shouldAlignWithDocumentLoad(): boolean {
 		return this._config.alignWebVitalsSpansWithDocumentLoad ?? true
+	}
+}
+
+function buildCommonAttributes(metric: Metric): Attributes {
+	return {
+		'webvitals.name': metric.name,
+		'webvitals.navigation_type': metric.navigationType,
+		'webvitals.rating': metric.rating,
+	}
+}
+
+function buildAttributionAttributes(name: string, metric: MetricWithAttribution): Attributes {
+	switch (name) {
+		case 'lcp': {
+			return buildLcpAttributes(metric as LCPMetricWithAttribution)
+		}
+		case 'cls': {
+			return buildClsAttributes(metric as CLSMetricWithAttribution)
+		}
+		case 'inp': {
+			return buildInpAttributes(metric as INPMetricWithAttribution)
+		}
+		case 'fcp': {
+			return buildFcpAttributes(metric as FCPMetricWithAttribution)
+		}
+		case 'ttfb': {
+			return buildTtfbAttributes(metric as TTFBMetricWithAttribution)
+		}
+		default: {
+			return {}
+		}
+	}
+}
+
+function buildLcpAttributes(metric: LCPMetricWithAttribution): Attributes {
+	const a = metric.attribution
+	return {
+		'lcp.element_render_delay': a.elementRenderDelay,
+		'lcp.resource_load_delay': a.resourceLoadDelay,
+		'lcp.resource_load_duration': a.resourceLoadDuration,
+		'lcp.target': a.target ?? '',
+		'lcp.time_to_first_byte': a.timeToFirstByte,
+		'lcp.url': a.url ?? '',
+	}
+}
+
+function buildClsAttributes(metric: CLSMetricWithAttribution): Attributes {
+	const a = metric.attribution
+	return {
+		'cls.largest_shift_target': a.largestShiftTarget ?? '',
+		'cls.largest_shift_time': a.largestShiftTime ?? 0,
+		'cls.largest_shift_value': a.largestShiftValue ?? 0,
+		'cls.load_state': a.loadState ?? '',
+	}
+}
+
+function buildInpAttributes(metric: INPMetricWithAttribution): Attributes {
+	const a = metric.attribution
+	return {
+		'inp.input_delay': a.inputDelay,
+		'inp.interaction_target': a.interactionTarget ?? '',
+		'inp.interaction_type': a.interactionType ?? '',
+		'inp.load_state': a.loadState ?? '',
+		'inp.presentation_delay': a.presentationDelay,
+		'inp.processing_duration': a.processingDuration,
+	}
+}
+
+function buildFcpAttributes(metric: FCPMetricWithAttribution): Attributes {
+	const a = metric.attribution
+	return {
+		'fcp.first_byte_to_fcp': a.firstByteToFCP,
+		'fcp.load_state': a.loadState ?? '',
+		'fcp.time_to_first_byte': a.timeToFirstByte,
+	}
+}
+
+function buildTtfbAttributes(metric: TTFBMetricWithAttribution): Attributes {
+	const a = metric.attribution
+	return {
+		'ttfb.cache_duration': a.cacheDuration,
+		'ttfb.connection_duration': a.connectionDuration,
+		'ttfb.dns_duration': a.dnsDuration,
+		'ttfb.request_duration': a.requestDuration,
+		'ttfb.waiting_duration': a.waitingDuration,
 	}
 }


### PR DESCRIPTION
# Description

## Problem Statement
Today, the webvitals instrumentation in `@splunk/otel-web` reports only Core Web Vitals values (CLS, LCP, INP) — single numbers like lcp: 2400. There's no signal in the span explaining details: which DOM element was the LCP target, which interaction caused the worst INP, what shifted to produce the CLS score, or how the number broke down across network/render phases.  Engineers have to reproduce locally and re-instrument to diagnose. 

Additionally, FCP and TTFB — both standard web-vitals metrics — aren't reported at all, leaving gaps in page-load performance visibility.

This change exposes the per-metric attribution data that web-vitals already computes (target selectors, timing breakdowns, load state) and adds opt-in FCP/TTFB span emission, so spans become self-diagnosing without code changes on the consumer side. All behavior is gated behind _experimental_* flags so existing span shape and volume are unaffected for consumers who don't opt in.

## Details
Adds opt-in support for richer web vitals telemetry on @splunk/otel-web's webvitals instrumentation by switching to the web-vitals/attribution subpath import. Three new experimental config flags surface additional data without changing default behavior:
- `_experimental_attribution` — when enabled, every emitted webvitals span gains common attributes (webvitals.name, webvitals.rating, webvitals.navigation_type) plus per-metric attribution attributes describing what caused the value (e.g. lcp.target, lcp.url, lcp.element_render_delay, cls.largest_shift_target, inp.interaction_type, inp.input_delay, etc.)
- `_experimental_fcp` — opt into First Contentful Paint as a webvitals span (with FCP attribution attributes when _experimental_attribution is also enabled). Accepts `boolean | ReportOpts`, mirroring the existing cls/inp/lcp shape.
- `_experimental_ttfb` — opt into Time to First Byte as a webvitals span (with TTFB attribution attributes when _experimental_attribution is also enabled). Same `boolean | ReportOpts` shape.

All three flags default to false, so existing consumers see identical span shape and volume. The _experimental_* prefix follows the project's established lifecycle convention (`_experimental_adjustSessionStartToTimeOrigin`, `_experimental_discardDataAfterInactivity`, etc.); the prefix will be dropped and the default flipped in a future minor release.

The span name remains `webvitals` and the existing per-metric value attribute (tags.lcp, tags.cls, tags.inp) is unchanged, preserving backward compatibility with consumer dashboards and the existing integration tests.

## Type of change


- New feature (non-breaking change which adds functionality)

# How has this been tested?




- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
