### PR TITLE
fix: increase size limit for artifacts/splunk-otel-web.js

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -23,7 +23,7 @@ module.exports = [
 	},
 
 	{
-		limit: '103 kB',
+		limit: '104 kB',
 		name: 'artifacts/splunk-otel-web.js',
 		path: './packages/web/dist/artifacts/splunk-otel-web.js',
 	},


### PR DESCRIPTION
# Description

Increased size limit for artifacts/splunk-otel-web.js

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)