### PR TITLE
chore: set spa metrics quiet time default to 1s

### DIFF
--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -28,7 +28,7 @@ describe('SpaMetricsManager', () => {
 		// @ts-expect-error Config is private. We use it for testing.
 		const config = manager.config
 
-		expect(config.quietTime).toBe(5000)
+		expect(config.quietTime).toBe(1000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toEqual([])
 	})

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -24,7 +24,7 @@ import { QuietPeriodAwaiter } from './quiet-period-awaiter'
 const SPA_METRICS_MANAGER_CONFIG_DEFAULTS = {
 	ignoreUrls: [] as (string | RegExp)[],
 	maxResourcesToWatch: 100,
-	quietTime: 5000,
+	quietTime: 1000,
 } as const
 
 export interface SpaMetricsManagerConfig {
@@ -123,7 +123,7 @@ export class SpaMetricsManager {
 
 		if (this.loadingResourcesCount === 0) {
 			this.quietPeriodAwaiter.startQuietTimer({ resourceLoadedTimestamp: startTime })
-			diag.debug('No loading resources. Starting quit timer.')
+			diag.debug('No loading resources. Starting quiet timer.')
 		}
 
 		return this.quietPeriodAwaiter.promise
@@ -150,7 +150,7 @@ export class SpaMetricsManager {
 				}
 
 				if (this.loadingResourcesCount === 0) {
-					diag.debug('No loading resources. Starting quit timer.')
+					diag.debug('No loading resources. Starting quiet timer.')
 					this.quietPeriodAwaiter.startQuietTimer({ resourceLoadedTimestamp: event.timestamp })
 				}
 			}


### PR DESCRIPTION
# Description

set spa metrics quiet time default to 1s (used to be 5 seconds)

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
