### PR TITLE
feat: add maxResourceWaitingTime to SpaMetricsManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
 		"eslint-plugin-perfectionist": "^5.9.0",
 		"eslint-plugin-prettier": "^5.5.5",
 		"eslint-plugin-unicorn": "^64.0.0",
+		"@fastify/cors": "^11.2.0",
 		"fastify": "^5.8.5",
 		"globals": "^17.4.0",
 		"markdownlint-cli": "^0.48.0",

--- a/packages/web/src/managers/spa-metrics-manager/monitors/fetch-xhr-monitor.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/fetch-xhr-monitor.test.ts
@@ -47,6 +47,7 @@ describe('FetchXhrMonitor', () => {
 			expect(events[0].state).toBe(ResourceState.DISCOVERED)
 			expect(events[1].state).toBe(ResourceState.LOADED)
 			expect(events[1]).toHaveProperty('loadTime')
+			expect(events[0].id).toBe(events[1].id)
 		})
 
 		it('ignores URLs matching pattern', async () => {
@@ -85,6 +86,44 @@ describe('FetchXhrMonitor', () => {
 			})
 
 			expect(events.length).toBe(0)
+		})
+	})
+
+	describe('maxResourceWaitingTime', () => {
+		const HTTP_SERVER = 'http://127.0.0.1:8981'
+
+		it('emits TIMEOUT for resource that exceeds maxResourceWaitingTime', async () => {
+			monitor.stop()
+			events = []
+			monitor = new FetchXhrMonitor({
+				maxResourceWaitingTime: 100,
+				onResourceStateChange: (event) => events.push(event),
+			})
+			monitor.start()
+
+			fetch(`${HTTP_SERVER}/delay?delay=5000`).catch(() => {})
+
+			await new Promise((resolve) => setTimeout(resolve, 150))
+
+			expect(events.some((e) => e.state === ResourceState.TIMEOUT)).toBe(true)
+			const timeoutEvent = events.find((e) => e.state === ResourceState.TIMEOUT)
+			expect(timeoutEvent?.url).toBe(`${HTTP_SERVER}/delay?delay=5000`)
+		})
+
+		it('does not emit TIMEOUT if resource completes in time', async () => {
+			monitor.stop()
+			events = []
+			monitor = new FetchXhrMonitor({
+				maxResourceWaitingTime: 500,
+				onResourceStateChange: (event) => events.push(event),
+			})
+			monitor.start()
+
+			await fetch(`${HTTP_SERVER}/delay?delay=10`)
+
+			await new Promise((resolve) => setTimeout(resolve, 50))
+
+			expect(events.some((e) => e.state === ResourceState.TIMEOUT)).toBe(false)
 		})
 	})
 

--- a/packages/web/src/managers/spa-metrics-manager/monitors/fetch-xhr-monitor.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/fetch-xhr-monitor.ts
@@ -20,7 +20,7 @@ import { diag } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 import * as shimmer from 'shimmer'
 
-import { Monitor, ResourceState } from './monitor'
+import { Monitor } from './monitor'
 
 declare global {
 	interface XMLHttpRequest {
@@ -52,6 +52,7 @@ export class FetchXhrMonitor extends Monitor {
 
 		this.restoreFetch()
 		this.restoreXhr()
+		this.stopTimeouts()
 
 		this.isMonitoring = false
 
@@ -76,27 +77,20 @@ export class FetchXhrMonitor extends Monitor {
 						return original(input, init)
 					}
 
+					const event = Monitor.createDiscoveredEvent(url)
 					const startTime = performance.now()
 
-					self.config.onResourceStateChange({ state: ResourceState.DISCOVERED, url })
+					self.emitResourceStateChange(event)
 
 					return original(input, init)
 						.then((response) => {
-							const loadTime = performance.now() - startTime
-							self.config.onResourceStateChange({
-								loadTime,
-								state: ResourceState.LOADED,
-								timestamp: performance.now(),
-								url,
-							})
+							self.emitResourceStateChange(
+								Monitor.createLoadedEvent(event.id, url, performance.now() - startTime),
+							)
 							return response
 						})
 						.catch((error) => {
-							self.config.onResourceStateChange({
-								state: ResourceState.ERROR,
-								timestamp: performance.now(),
-								url,
-							})
+							self.emitResourceStateChange(Monitor.createErrorEvent(event.id, url))
 							throw error
 						})
 				},
@@ -130,27 +124,20 @@ export class FetchXhrMonitor extends Monitor {
 				function wrappedSend(this: XMLHttpRequest, body?: Document | XMLHttpRequestBodyInit | null): void {
 					const url = this._splunkMonitorUrl
 					if (url && !isUrlIgnored(url, self.config.ignoreUrls)) {
+						const event = Monitor.createDiscoveredEvent(url)
 						const startTime = performance.now()
 
-						self.config.onResourceStateChange({ state: ResourceState.DISCOVERED, url })
+						self.emitResourceStateChange(event)
 
 						const loadHandler = () => {
-							const loadTime = performance.now() - startTime
-							self.config.onResourceStateChange({
-								loadTime,
-								state: ResourceState.LOADED,
-								timestamp: performance.now(),
-								url,
-							})
+							self.emitResourceStateChange(
+								Monitor.createLoadedEvent(event.id, url, performance.now() - startTime),
+							)
 							cleanup()
 						}
 
 						const errorHandler = () => {
-							self.config.onResourceStateChange({
-								state: ResourceState.ERROR,
-								timestamp: performance.now(),
-								url,
-							})
+							self.emitResourceStateChange(Monitor.createErrorEvent(event.id, url))
 							cleanup()
 						}
 

--- a/packages/web/src/managers/spa-metrics-manager/monitors/media-monitor.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/media-monitor.ts
@@ -20,7 +20,7 @@ import { diag } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
 import { isElement, isMediaElement } from '../../../types'
-import { Monitor, ResourceState } from './monitor'
+import { Monitor } from './monitor'
 
 export class MediaMonitor extends Monitor {
 	private isMonitoring = false
@@ -50,6 +50,7 @@ export class MediaMonitor extends Monitor {
 
 		this.observer?.disconnect()
 		this.observer = null
+		this.stopTimeouts()
 
 		this.isMonitoring = false
 
@@ -70,31 +71,26 @@ export class MediaMonitor extends Monitor {
 		}
 
 		this.monitoredMediaElements.add(element)
+		const event = Monitor.createDiscoveredEvent(element.src)
+
 		if (this.isElementAlreadyLoaded(element)) {
-			this.config.onResourceStateChange({
-				loadTime: 0,
-				state: ResourceState.LOADED,
-				timestamp: performance.now(),
-				url: element.src,
-			})
+			this.emitResourceStateChange(Monitor.createLoadedEvent(event.id, element.src, 0))
 			return
 		} else {
-			this.config.onResourceStateChange({ state: ResourceState.DISCOVERED, url: element.src })
+			this.emitResourceStateChange(event)
 		}
 
 		const startTime = performance.now()
 		const listener = () => {
-			this.config.onResourceStateChange({
-				loadTime: performance.now() - startTime,
-				state: ResourceState.LOADED,
-				timestamp: performance.now(),
-				url: element.src,
-			})
+			this.emitResourceStateChange(
+				Monitor.createLoadedEvent(event.id, element.src, performance.now() - startTime),
+			)
 			element.removeEventListener('load', listener)
 			element.removeEventListener('error', errorListener)
 		}
 
 		const errorListener = () => {
+			this.emitResourceStateChange(Monitor.createErrorEvent(event.id, element.src))
 			element.removeEventListener('load', listener)
 			element.removeEventListener('error', errorListener)
 		}

--- a/packages/web/src/managers/spa-metrics-manager/monitors/monitor.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/monitor.ts
@@ -16,27 +16,96 @@
  *
  */
 
+import { diag } from '@opentelemetry/api'
+
+import { generateId } from '../../../utils'
+
 export enum ResourceState {
 	DISCOVERED = 'discovered',
 	ERROR = 'error',
 	LOADED = 'loaded',
+	TIMEOUT = 'timeout',
 }
 
 export type ResourceStateEvent =
-	| { state: ResourceState.DISCOVERED; url: string }
-	| { state: ResourceState.ERROR; timestamp: number; url: string }
-	| { loadTime: number; state: ResourceState.LOADED; timestamp: number; url: string }
+	| { id: string; state: ResourceState.DISCOVERED; url: string }
+	| { id: string; state: ResourceState.ERROR; timestamp: number; url: string }
+	| { id: string; loadTime: number; state: ResourceState.LOADED; timestamp: number; url: string }
+	| { id: string; state: ResourceState.TIMEOUT; timestamp: number; url: string }
 
 export interface MonitorConfig {
 	ignoreUrls?: (string | RegExp)[]
+	maxResourceWaitingTime?: number
 	onResourceStateChange: (event: ResourceStateEvent) => void
 }
 
 export abstract class Monitor {
 	protected config: MonitorConfig
 
+	private resourceTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
 	constructor(config: MonitorConfig) {
 		this.config = config
+	}
+
+	static createDiscoveredEvent(url: string): ResourceStateEvent & { state: ResourceState.DISCOVERED } {
+		return { id: generateId(64), state: ResourceState.DISCOVERED, url }
+	}
+
+	static createErrorEvent(id: string, url: string): ResourceStateEvent & { state: ResourceState.ERROR } {
+		return { id, state: ResourceState.ERROR, timestamp: performance.now(), url }
+	}
+
+	static createLoadedEvent(
+		id: string,
+		url: string,
+		loadTime: number,
+	): ResourceStateEvent & { state: ResourceState.LOADED } {
+		return { id, loadTime, state: ResourceState.LOADED, timestamp: performance.now(), url }
+	}
+
+	static createTimeoutEvent(id: string, url: string): ResourceStateEvent & { state: ResourceState.TIMEOUT } {
+		return { id, state: ResourceState.TIMEOUT, timestamp: performance.now(), url }
+	}
+
+	protected emitResourceStateChange(event: ResourceStateEvent): void {
+		if (event.state === ResourceState.DISCOVERED) {
+			this.startResourceTimeout(event.id, event.url)
+		} else {
+			this.clearResourceTimeout(event.id)
+		}
+
+		this.config.onResourceStateChange(event)
+	}
+
+	protected stopTimeouts(): void {
+		for (const timerId of this.resourceTimeouts.values()) {
+			clearTimeout(timerId)
+		}
+		this.resourceTimeouts.clear()
+	}
+
+	private clearResourceTimeout(id: string): void {
+		const timerId = this.resourceTimeouts.get(id)
+		if (timerId !== undefined) {
+			clearTimeout(timerId)
+			this.resourceTimeouts.delete(id)
+		}
+	}
+
+	private startResourceTimeout(id: string, url: string): void {
+		if (this.config.maxResourceWaitingTime === undefined) {
+			return
+		}
+
+		this.resourceTimeouts.set(
+			id,
+			setTimeout(() => {
+				this.resourceTimeouts.delete(id)
+				diag.debug('Monitor: Resource exceeded max waiting time', url)
+				this.config.onResourceStateChange(Monitor.createTimeoutEvent(id, url))
+			}, this.config.maxResourceWaitingTime),
+		)
 	}
 
 	abstract start(): void

--- a/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.test.ts
@@ -76,10 +76,12 @@ describe('PerformanceMonitor', () => {
 		// Clean up
 		link.remove()
 
-		// Should have detected the CSS file
+		// Should have detected the CSS file (DISCOVERED + LOADED)
 		const cssEvents = events.filter((e) => e.url.includes('bootstrap'))
-		expect(cssEvents.length).toBeGreaterThan(0)
-		expect(cssEvents[0].state).toBe(ResourceState.LOADED)
+		expect(cssEvents.length).toBeGreaterThanOrEqual(2)
+		expect(cssEvents[0].state).toBe(ResourceState.DISCOVERED)
+		expect(cssEvents[1].state).toBe(ResourceState.LOADED)
+		expect(cssEvents[0].id).toBe(cssEvents[1].id)
 	})
 
 	it('ignores URLs matching ignore pattern', async () => {

--- a/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.ts
@@ -19,7 +19,7 @@
 import { diag } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
-import { Monitor, ResourceState } from './monitor'
+import { Monitor } from './monitor'
 
 const RESOURCE_TYPES_TO_MONITOR = new Set(['css', 'font', 'img', 'link', 'other'])
 
@@ -81,12 +81,9 @@ export class PerformanceMonitor extends Monitor {
 
 		const loadTime = entry.responseEnd - entry.startTime
 
-		this.config.onResourceStateChange({
-			loadTime,
-			state: ResourceState.LOADED,
-			timestamp: entry.responseEnd,
-			url,
-		})
+		const event = Monitor.createDiscoveredEvent(url)
+		this.emitResourceStateChange(event)
+		this.emitResourceStateChange(Monitor.createLoadedEvent(event.id, url, loadTime))
 
 		diag.debug('PageLoadingManager.PerformanceMonitor: Resource loaded', {
 			initiatorType: entry.initiatorType,

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -30,6 +30,7 @@ describe('SpaMetricsManager', () => {
 
 		expect(config.quietTime).toBe(1000)
 		expect(config.maxResourcesToWatch).toBe(100)
+		expect(config.maxResourceWaitingTime).toBe(60_000)
 		expect(config.ignoreUrls).toEqual([])
 	})
 
@@ -112,20 +113,21 @@ describe('SpaMetricsManager', () => {
 		const onResourceStateChange = manager.onResourceStateChange
 
 		// Simulate resource discovery
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url: 'https://example.com/api' })
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.size).toBe(1)
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url: 'https://example.com/api' })
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(1)
 
 		// Simulate resource loaded
 		onResourceStateChange({
+			id: 'r_1',
 			loadTime: 50,
 			state: ResourceState.LOADED,
 			timestamp: performance.now(),
 			url: 'https://example.com/api',
 		})
 
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.size).toBe(0)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(0)
 
 		manager.stop()
 	})
@@ -138,21 +140,128 @@ describe('SpaMetricsManager', () => {
 		const onResourceStateChange = manager.onResourceStateChange
 		const url = 'https://example.com/api'
 
-		// Two requests to same URL
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url })
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url })
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.get(url)).toBe(2)
+		// Two requests to same URL with different IDs
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url })
+		onResourceStateChange({ id: 'r_2', state: ResourceState.DISCOVERED, url })
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(2)
 
 		// First completes
-		onResourceStateChange({ loadTime: 50, state: ResourceState.LOADED, timestamp: 0, url })
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.get(url)).toBe(1)
+		onResourceStateChange({ id: 'r_1', loadTime: 50, state: ResourceState.LOADED, timestamp: 0, url })
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(1)
 
 		// Second completes
-		onResourceStateChange({ loadTime: 50, state: ResourceState.LOADED, timestamp: 0, url })
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.has(url)).toBe(false)
+		onResourceStateChange({ id: 'r_2', loadTime: 50, state: ResourceState.LOADED, timestamp: 0, url })
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(0)
+
+		manager.stop()
+	})
+
+	it('resolves waitForPageLoad when TIMEOUT event removes the last pending resource', async () => {
+		const manager = new SpaMetricsManager({ quietTime: 50 })
+		manager.start()
+
+		// @ts-expect-error onResourceStateChange is private. We use it for testing.
+		const onResourceStateChange = manager.onResourceStateChange
+
+		const promise = manager.waitForPageLoad({ startTime: performance.now() })
+
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url: 'https://example.com/slow' })
+
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.has('r_1')).toBe(true)
+
+		onResourceStateChange({
+			id: 'r_1',
+			state: ResourceState.TIMEOUT,
+			timestamp: performance.now(),
+			url: 'https://example.com/slow',
+		})
+
+		const result = await promise
+
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.has('r_1')).toBe(false)
+		expect(result).toHaveProperty('loadTime')
+
+		manager.stop()
+	})
+
+	it('resolves normally when resource completes before maxResourceWaitingTime', async () => {
+		const manager = new SpaMetricsManager({ maxResourceWaitingTime: 500, quietTime: 50 })
+		manager.start()
+
+		// @ts-expect-error onResourceStateChange is private. We use it for testing.
+		const onResourceStateChange = manager.onResourceStateChange
+
+		const promise = manager.waitForPageLoad({ startTime: performance.now() })
+
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url: 'https://example.com/fast' })
+		onResourceStateChange({
+			id: 'r_1',
+			loadTime: 10,
+			state: ResourceState.LOADED,
+			timestamp: performance.now(),
+			url: 'https://example.com/fast',
+		})
+
+		const result = await promise
+		expect(result.loadTime).toBeLessThan(100)
+
+		manager.stop()
+	})
+
+	it('handles TIMEOUT event through onResourceStateChange', () => {
+		const manager = new SpaMetricsManager({ maxResourceWaitingTime: 500 })
+		manager.start()
+
+		// @ts-expect-error onResourceStateChange is private. We use it for testing.
+		const onResourceStateChange = manager.onResourceStateChange
+
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url: 'https://example.com/slow' })
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.has('r_1')).toBe(true)
+
+		onResourceStateChange({
+			id: 'r_1',
+			state: ResourceState.TIMEOUT,
+			timestamp: performance.now(),
+			url: 'https://example.com/slow',
+		})
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.has('r_1')).toBe(false)
+
+		manager.stop()
+	})
+
+	it('ignores late LOADED event after TIMEOUT', () => {
+		const manager = new SpaMetricsManager({ maxResourceWaitingTime: 500 })
+		manager.start()
+
+		// @ts-expect-error onResourceStateChange is private. We use it for testing.
+		const onResourceStateChange = manager.onResourceStateChange
+
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url: 'https://example.com/slow' })
+		onResourceStateChange({
+			id: 'r_1',
+			state: ResourceState.TIMEOUT,
+			timestamp: performance.now(),
+			url: 'https://example.com/slow',
+		})
+
+		// Late LOADED after timeout should not throw or change state
+		onResourceStateChange({
+			id: 'r_1',
+			loadTime: 70_000,
+			state: ResourceState.LOADED,
+			timestamp: performance.now(),
+			url: 'https://example.com/slow',
+		})
+
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(0)
 
 		manager.stop()
 	})
@@ -165,33 +274,39 @@ describe('SpaMetricsManager', () => {
 		const onResourceStateChange = manager.onResourceStateChange
 
 		// Add resources up to limit
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url: 'https://example.com/1' })
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url: 'https://example.com/2' })
+		onResourceStateChange({ id: 'r_1', state: ResourceState.DISCOVERED, url: 'https://example.com/1' })
+		onResourceStateChange({ id: 'r_2', state: ResourceState.DISCOVERED, url: 'https://example.com/2' })
 
 		// @ts-expect-error loadingResourcesCount is private. We use it for testing.
 		expect(manager.loadingResourcesCount).toBe(2)
 
 		// Try to add beyond limit - should be ignored
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url: 'https://example.com/3' })
+		onResourceStateChange({ id: 'r_3', state: ResourceState.DISCOVERED, url: 'https://example.com/3' })
 
 		// @ts-expect-error loadingResourcesCount is private. We use it for testing.
 		expect(manager.loadingResourcesCount).toBe(2)
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.has('https://example.com/3')).toBe(false)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.has('r_3')).toBe(false)
 
 		// Complete one resource
-		onResourceStateChange({ loadTime: 50, state: ResourceState.LOADED, timestamp: 0, url: 'https://example.com/1' })
+		onResourceStateChange({
+			id: 'r_1',
+			loadTime: 50,
+			state: ResourceState.LOADED,
+			timestamp: 0,
+			url: 'https://example.com/1',
+		})
 
 		// @ts-expect-error loadingResourcesCount is private. We use it for testing.
 		expect(manager.loadingResourcesCount).toBe(1)
 
 		// Now new resource can be added
-		onResourceStateChange({ state: ResourceState.DISCOVERED, url: 'https://example.com/3' })
+		onResourceStateChange({ id: 'r_4', state: ResourceState.DISCOVERED, url: 'https://example.com/3' })
 
 		// @ts-expect-error loadingResourcesCount is private. We use it for testing.
 		expect(manager.loadingResourcesCount).toBe(2)
-		// @ts-expect-error loadingUrls is private. We use it for testing.
-		expect(manager.loadingUrls.has('https://example.com/3')).toBe(true)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.has('r_4')).toBe(true)
 
 		manager.stop()
 	})

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -24,12 +24,14 @@ import { QuietPeriodAwaiter } from './quiet-period-awaiter'
 const SPA_METRICS_MANAGER_CONFIG_DEFAULTS = {
 	ignoreUrls: [] as (string | RegExp)[],
 	maxResourcesToWatch: 100,
+	maxResourceWaitingTime: 60_000,
 	quietTime: 1000,
 } as const
 
 export interface SpaMetricsManagerConfig {
 	beaconEndpoint?: string
 	ignoreUrls?: (string | RegExp)[]
+	maxResourceWaitingTime?: number
 	maxResourcesToWatch?: number
 	quietTime?: number
 }
@@ -41,14 +43,10 @@ export class SpaMetricsManager {
 
 	private isMonitoring = false
 
-	private loadingUrls = new Map<string, number>()
+	private loadingResources = new Set<string>()
 
 	private get loadingResourcesCount(): number {
-		let count = 0
-		for (const value of this.loadingUrls.values()) {
-			count += value
-		}
-		return count
+		return this.loadingResources.size
 	}
 
 	private mediaMonitor: MediaMonitor
@@ -72,14 +70,18 @@ export class SpaMetricsManager {
 		this.config = {
 			ignoreUrls,
 			maxResourcesToWatch: config.maxResourcesToWatch ?? SPA_METRICS_MANAGER_CONFIG_DEFAULTS.maxResourcesToWatch,
+			maxResourceWaitingTime:
+				config.maxResourceWaitingTime ?? SPA_METRICS_MANAGER_CONFIG_DEFAULTS.maxResourceWaitingTime,
 			quietTime: config.quietTime ?? SPA_METRICS_MANAGER_CONFIG_DEFAULTS.quietTime,
 		}
 
 		this.fetchXhrMonitor = new FetchXhrMonitor({
 			ignoreUrls: this.config.ignoreUrls,
+			maxResourceWaitingTime: this.config.maxResourceWaitingTime,
 			onResourceStateChange: this.onResourceStateChange,
 		})
 		this.mediaMonitor = new MediaMonitor({
+			maxResourceWaitingTime: this.config.maxResourceWaitingTime,
 			onResourceStateChange: this.onResourceStateChange,
 		})
 		this.performanceMonitor = new PerformanceMonitor({
@@ -112,7 +114,7 @@ export class SpaMetricsManager {
 		this.fetchXhrMonitor.stop()
 		this.mediaMonitor.stop()
 		this.performanceMonitor.stop()
-		this.loadingUrls.clear()
+		this.loadingResources.clear()
 
 		diag.debug('SpaMetricsManager: Stopped monitoring.')
 	}
@@ -136,19 +138,11 @@ export class SpaMetricsManager {
 				return
 			}
 
-			const count = this.loadingUrls.get(event.url) ?? 0
-			this.loadingUrls.set(event.url, count + 1)
+			this.loadingResources.add(event.id)
 			diag.debug('Detected resource. Resetting quiet timer', event.url)
 			this.quietPeriodAwaiter.removeQuietTimer()
 		} else {
-			const count = this.loadingUrls.get(event.url) ?? 0
-			if (count > 0) {
-				if (count === 1) {
-					this.loadingUrls.delete(event.url)
-				} else {
-					this.loadingUrls.set(event.url, count - 1)
-				}
-
+			if (this.loadingResources.delete(event.id)) {
 				if (this.loadingResourcesCount === 0) {
 					diag.debug('No loading resources. Starting quiet timer.')
 					this.quietPeriodAwaiter.startQuietTimer({ resourceLoadedTimestamp: event.timestamp })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.3.0(jiti@2.6.1))
+      '@fastify/cors':
+        specifier: ^11.2.0
+        version: 11.2.0
       '@octokit/request':
         specifier: ^10.0.8
         version: 10.0.8

--- a/tests/global-setup.ts
+++ b/tests/global-setup.ts
@@ -15,7 +15,7 @@
  * limitations under the License.
  *
  */
-import { initSocketIo, initWebSocketServer } from './servers'
+import { initHttpServer, initSocketIo, initWebSocketServer } from './servers'
 
 let teardown = false
 let isRunning = false
@@ -25,6 +25,7 @@ export default function globalSetup() {
 		return
 	}
 
+	const closeHttpServer = initHttpServer()
 	const closeSocketIoServer = initSocketIo()
 	const closeWebSocketServer = initWebSocketServer()
 
@@ -37,6 +38,6 @@ export default function globalSetup() {
 
 		teardown = true
 
-		await Promise.all([closeSocketIoServer(), closeWebSocketServer()])
+		await Promise.all([closeHttpServer(), closeSocketIoServer(), closeWebSocketServer()])
 	}
 }

--- a/tests/servers/http.ts
+++ b/tests/servers/http.ts
@@ -15,6 +15,28 @@
  * limitations under the License.
  *
  */
-export * from './http'
-export * from './socket-io'
-export * from './websocket'
+import cors from '@fastify/cors'
+import Fastify from 'fastify'
+
+export const HTTP_SERVER_PORT = 8981
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
+
+export const initHttpServer = () => {
+	const fastify = Fastify()
+
+	fastify.register(cors)
+
+	fastify.get<{ Querystring: { delay?: string } }>('/delay', async (request, reply) => {
+		const delay = Number.parseInt(request.query.delay ?? '0', 10)
+		if (!Number.isNaN(delay) && delay > 0) {
+			await sleep(delay)
+		}
+
+		reply.send('ok')
+	})
+
+	void fastify.listen({ port: HTTP_SERVER_PORT })
+
+	return () => fastify.close()
+}


### PR DESCRIPTION
# Description

- Add `maxResourceWaitingTime` (default 60s) config to SpaMetricsManager that sets a per-resource timeout on fetch/XHR and media monitors
- Each monitored resource gets a unique ID and its own timer — when a resource exceeds the timeout, monitors emit a `ResourceState.TIMEOUT` event which removes it from the pending loading urls set

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
