### PR TITLE
feat: mark page load metrics interrupted on page hide

### DIFF
--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -169,9 +169,9 @@ test.describe('docload', () => {
 
 		// pct uses the same loadEventEnd - fetchStart calculation as the exported documentLoad span.
 		const durationMs = hrTimeToMilliseconds(docLoadSpan.duration)
-		// The span duration is serialized through OTLP HrTime and converted back to milliseconds,
-		// so equal browser timings can differ by a tiny floating-point rounding error.
-		expect(pct).toBeGreaterThanOrEqual(durationMs - 0.001)
+		// The span duration is serialized through OTLP HrTime and converted back to milliseconds.
+		// WebKit can report an equivalent integer PCT while durationMs lands just below the next millisecond.
+		expect(pct).toBeGreaterThanOrEqual(Math.floor(durationMs))
 	})
 
 	test('module can be disabled', async ({ recordPage }) => {

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -29,7 +29,12 @@ import { Span } from '@opentelemetry/sdk-trace-base'
 import { addSpanNetworkEvents, PerformanceEntries, PerformanceTimingNames as PTN } from '@opentelemetry/sdk-trace-web'
 import { SemanticAttributes, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions'
 
-import { SessionManager, SpaMetricsManager } from '../managers'
+import {
+	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
+	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+	SessionManager,
+	SpaMetricsManager,
+} from '../managers'
 import { captureTraceParentFromPerformanceEntries } from '../servertiming'
 import { SplunkOtelWebConfig } from '../types'
 import { isCacheHit } from '../utils/cache'
@@ -158,12 +163,16 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 
 				if (this.documentLoadMetricsPromise) {
 					void this.documentLoadMetricsPromise
-						.then(({ pct, timeout }) => {
-							span.setAttribute('browser.navigation.page_completion_time', pct)
-							if (timeout) {
-								span.setAttribute('browser.navigation.status', 'timeout')
+						.then(({ pct, status }) => {
+							span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
+							if (status) {
+								span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
 							}
 
+							api.diag.debug('Sending documentLoad span with PCT result', {
+								pct,
+								status,
+							})
 							_superEndSpan(span, performanceName, entries)
 						})
 						.catch((error) => {

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -19,7 +19,12 @@
 import { diag, Span, trace, Tracer, TracerProvider } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
-import { SessionManager, SpaMetricsManager } from '../managers'
+import {
+	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
+	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+	SessionManager,
+	SpaMetricsManager,
+} from '../managers'
 import { SplunkOtelWebConfig } from '../types'
 import { UserInteractionInstrumentation } from '../upstream/user-interaction/instrumentation'
 import { UserInteractionInstrumentationConfig } from '../upstream/user-interaction/types'
@@ -197,15 +202,19 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		if (this.spaMetricsManager) {
 			// Wait for all in-flight resources (XHR, fetch, media) to finish loading,
 			// then resolve after a quiet period with no new network activity.
-			const { pct, timeout } = await this.spaMetricsManager.waitForPageLoad({
+			const { pct, status } = await this.spaMetricsManager.waitForPageLoad({
 				startTime: performance.now(),
 			})
 
-			span.setAttribute('browser.navigation.page_completion_time', pct)
-			if (timeout) {
-				span.setAttribute('browser.navigation.status', 'timeout')
+			span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
+			if (status) {
+				span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
 			}
 
+			diag.debug('Sending routeChange span with PCT result', {
+				pct,
+				status,
+			})
 			span.end(now + pct)
 			diag.debug('Route change span ended', { pct, span })
 		} else {

--- a/packages/web/src/managers/spa-metrics-manager/constants.ts
+++ b/packages/web/src/managers/spa-metrics-manager/constants.ts
@@ -16,5 +16,8 @@
  *
  */
 
-export * from './constants'
-export * from './spa-metrics-manager'
+export const BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE = 'browser.navigation.page_completion_time'
+export const BROWSER_NAVIGATION_STATUS_ATTRIBUTE = 'browser.navigation.status'
+
+export const PAGE_LOAD_METRICS_STATUS_INTERRUPTED = 'interrupted'
+export const PAGE_LOAD_METRICS_STATUS_TIMEOUT = 'timeout'

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
@@ -17,6 +17,7 @@
  */
 import { describe, expect, it } from 'vitest'
 
+import { PAGE_LOAD_METRICS_STATUS_INTERRUPTED, PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
 import { QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 describe('QuietPeriodAwaiter', () => {
@@ -29,7 +30,7 @@ describe('QuietPeriodAwaiter', () => {
 
 		expect(result).toHaveProperty('pct')
 		expect(result.pct).toBe(10)
-		expect(result.timeout).toBe(false)
+		expect(result.status).toBeUndefined()
 	})
 
 	it('resets timer when removeQuietTimer is called', async () => {
@@ -44,7 +45,7 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 		expect(result.pct).toBeGreaterThanOrEqual(250)
 		expect(result.pct).toBeLessThan(300)
-		expect(result.timeout).toBe(false)
+		expect(result.status).toBeUndefined()
 	})
 
 	it('complete() resolves immediately', async () => {
@@ -53,17 +54,48 @@ describe('QuietPeriodAwaiter', () => {
 		awaiter.complete({ areResourcesStillLoading: false })
 		const result = await awaiter.promise
 		expect(result.pct).toBe(0)
-		expect(result.timeout).toBe(false)
+		expect(result.status).toBeUndefined()
 	})
 
-	it('resolves with timeout true when max page load wait time expires before quiet timer starts', async () => {
+	it('interrupt() resolves immediately with interrupted status', async () => {
+		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
+		awaiter.startQuietTimer({ resourceLoadedTimestamp: performance.now() + 100 })
+
+		awaiter.interrupt()
+		const result = await awaiter.promise
+
+		expect(result.pct).toBeGreaterThanOrEqual(0)
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+	})
+
+	it('resolves with interrupted status when persisted pagehide fires', async () => {
+		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
+		const event = new Event('pagehide') as PageTransitionEvent
+		Object.defineProperty(event, 'persisted', { value: true })
+
+		window.dispatchEvent(event)
+
+		const result = await awaiter.promise
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+	})
+
+	it('does not resolve with interrupted status when beforeunload fires', async () => {
+		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5 })
+
+		window.dispatchEvent(new Event('beforeunload'))
+
+		const result = await awaiter.promise
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+	})
+
+	it('resolves with timeout status when max page load wait time expires before quiet timer starts', async () => {
 		const startTime = performance.now()
 		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5, startTime })
 
 		const result = await awaiter.promise
 
 		expect(result.pct).toBe(10)
-		expect(result.timeout).toBe(true)
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
 	})
 
 	it('resolves only once when quiet period would expire after max page load wait time', async () => {
@@ -78,7 +110,7 @@ describe('QuietPeriodAwaiter', () => {
 
 		await new Promise((resolve) => setTimeout(resolve, 50))
 		expect(result.pct).toBe(30)
-		expect(result.timeout).toBe(true)
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
 		expect(results).toHaveLength(1)
 	})
 })

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
@@ -18,10 +18,21 @@
 
 import { diag } from '@opentelemetry/api'
 
+import { PAGE_LOAD_METRICS_STATUS_INTERRUPTED, PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
+
 const DEFAULT_MAX_PAGE_LOAD_WAIT_TIME = 180_000
 const DEFAULT_QUIET_TIME = 1000
+const INTERRUPT_LISTENER_OPTIONS: AddEventListenerOptions = { capture: true, once: true }
+const INTERRUPT_LISTENER_REMOVE_OPTIONS: EventListenerOptions = { capture: true }
 
-export type PageLoadMetricsResult = { pct: number; timeout: boolean }
+export type PageLoadMetricsStatus =
+	| typeof PAGE_LOAD_METRICS_STATUS_INTERRUPTED
+	| typeof PAGE_LOAD_METRICS_STATUS_TIMEOUT
+
+export type PageLoadMetricsResult = {
+	pct: number
+	status?: PageLoadMetricsStatus
+}
 
 type QuietPeriodAwaiterConfig = {
 	maxPageLoadWaitTime?: number
@@ -78,9 +89,10 @@ export class QuietPeriodAwaiter {
 			diag.debug('QuietPeriodAwaiter: Max page load wait time expired', { pct })
 			this.resolveOnce({
 				pct,
-				timeout: true,
+				status: PAGE_LOAD_METRICS_STATUS_TIMEOUT,
 			})
 		}, maxPageLoadWaitTime)
+		window.addEventListener('pagehide', this.interruptListener, INTERRUPT_LISTENER_OPTIONS)
 	}
 
 	complete({ areResourcesStillLoading }: { areResourcesStillLoading: boolean }): void {
@@ -98,7 +110,20 @@ export class QuietPeriodAwaiter {
 		diag.debug('QuietPeriodAwaiter: Complete', { pct })
 		this.resolveOnce({
 			pct,
-			timeout: false,
+		})
+	}
+
+	interrupt(): void {
+		if (this.isResolved) {
+			return
+		}
+
+		const endTimestamp = performance.now()
+		const pct = Math.max(endTimestamp - this.startTime, 0)
+		diag.debug('QuietPeriodAwaiter: Interrupted', { pct })
+		this.resolveOnce({
+			pct,
+			status: PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
 		})
 	}
 
@@ -120,12 +145,15 @@ export class QuietPeriodAwaiter {
 		clearTimeout(this.timeoutId)
 
 		this.timeoutId = setTimeout(() => {
-			diag.debug('QuietPeriodAwaiter: Quiet period expired')
+			diag.debug('QuietPeriodAwaiter: Quiet period expired', this.quietTime)
 			this.resolveOnce({
 				pct: Math.max(resourceLoadedTimestamp - this.startTime, 0),
-				timeout: false,
 			})
 		}, this.quietTime)
+	}
+
+	private readonly interruptListener = (): void => {
+		this.interrupt()
 	}
 
 	private readonly resolve: (resolveValue: PageLoadMetricsResult) => void = () => {}
@@ -140,6 +168,7 @@ export class QuietPeriodAwaiter {
 		clearTimeout(this.maxWaitTimeoutId)
 		this.timeoutId = undefined
 		this.maxWaitTimeoutId = undefined
+		window.removeEventListener('pagehide', this.interruptListener, INTERRUPT_LISTENER_REMOVE_OPTIONS)
 		this.resolve(resolveValue)
 	}
 }

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -20,6 +20,7 @@ import { diag } from '@opentelemetry/api'
 import { describe, expect, it, vi } from 'vitest'
 
 import { HTTP_TEST_SERVER_URL } from '../../../../../tests/servers/http-constants'
+import { PAGE_LOAD_METRICS_STATUS_INTERRUPTED, PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
 import { ResourceState } from './monitors'
 import { getDocumentLoadTime, SpaMetricsManager } from './spa-metrics-manager'
 
@@ -121,7 +122,7 @@ describe('SpaMetricsManager', () => {
 
 		const result = await promise
 		expect(result).toHaveProperty('pct')
-		expect(result.timeout).toBe(false)
+		expect(result.status).toBeUndefined()
 
 		manager.stop()
 	})
@@ -138,12 +139,12 @@ describe('SpaMetricsManager', () => {
 
 		expect(result.pct).toBeGreaterThanOrEqual(documentLoadTime)
 		expect(result.pct).toBeGreaterThan(0)
-		expect(result.timeout).toBe(false)
+		expect(result.status).toBeUndefined()
 
 		manager.stop()
 	})
 
-	it('waitForPageLoad resolves with timeout true when max page load wait time expires', async () => {
+	it('waitForPageLoad resolves with timeout status when max page load wait time expires', async () => {
 		const manager = new SpaMetricsManager({ maxPageLoadWaitTime: 3000, quietTime: 1000 })
 		manager.start()
 		const slowResourceAbortController = new AbortController()
@@ -156,11 +157,40 @@ describe('SpaMetricsManager', () => {
 			const result = await manager.waitForPageLoad({ startTime })
 
 			expect(result.pct).toBe(3000)
-			expect(result.timeout).toBe(true)
+			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
 		} finally {
 			slowResourceAbortController.abort()
 			manager.stop()
 		}
+	})
+
+	it('waitForPageLoad resolves with interrupted status when page hides', async () => {
+		const manager = new SpaMetricsManager({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
+		manager.start()
+
+		try {
+			const promise = manager.waitForPageLoad({ startTime: performance.now() })
+
+			// @ts-expect-error onResourceStateChange is private. We use it for testing.
+			manager.onResourceStateChange({ state: ResourceState.DISCOVERED, url: 'https://example.com/api' })
+			window.dispatchEvent(new Event('pagehide'))
+
+			const result = await promise
+			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		} finally {
+			manager.stop()
+		}
+	})
+
+	it('waitForPageLoad resolves with interrupted status when stopped', async () => {
+		const manager = new SpaMetricsManager({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
+		manager.start()
+
+		const promise = manager.waitForPageLoad({ startTime: performance.now() })
+		manager.stop()
+
+		const result = await promise
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
 	})
 
 	it('tracks loading resources and manages quiet timer', () => {

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -120,6 +120,9 @@ export class SpaMetricsManager {
 	}
 
 	stop(): void {
+		this.quietPeriodAwaiter?.interrupt()
+		this.quietPeriodAwaiter = undefined
+
 		if (!this.isMonitoring) {
 			return
 		}
@@ -135,20 +138,21 @@ export class SpaMetricsManager {
 
 	waitForPageLoad({ startTime }: { startTime: number }): Promise<PageLoadMetricsResult> {
 		this.quietPeriodAwaiter?.complete({ areResourcesStillLoading: this.loadingResourcesCount > 0 })
-		this.quietPeriodAwaiter = new QuietPeriodAwaiter({
+		const quietPeriodAwaiter = new QuietPeriodAwaiter({
 			maxPageLoadWaitTime: this.config.maxPageLoadWaitTime,
 			quietTime: this.config.quietTime,
 			startTime,
 		})
+		this.quietPeriodAwaiter = quietPeriodAwaiter
 
 		if (this.loadingResourcesCount === 0) {
-			this.quietPeriodAwaiter.startQuietTimer({ resourceLoadedTimestamp: startTime })
+			quietPeriodAwaiter.startQuietTimer({ resourceLoadedTimestamp: startTime })
 			diag.debug('No loading resources. Starting quiet timer.')
 		}
 
 		// startTime === 0 means this is a documentLoad pct — ensure it's at least the document load time
 		if (startTime === 0) {
-			return this.quietPeriodAwaiter.promise.then((result) => {
+			return quietPeriodAwaiter.promise.then((result) => {
 				const navEntry = performance.getEntriesByType('navigation')[0] as
 					| PerformanceNavigationTiming
 					| undefined
@@ -157,7 +161,7 @@ export class SpaMetricsManager {
 			})
 		}
 
-		return this.quietPeriodAwaiter.promise
+		return quietPeriodAwaiter.promise
 	}
 
 	private onResourceStateChange = (event: ResourceStateEvent): void => {

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -23,6 +23,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { HTTP_TEST_SERVER_URL } from '../../../tests/servers/http-constants'
 import SplunkRum from '../src'
+import {
+	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
+	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+} from '../src/managers'
 import { VERSION } from '../src/version'
 import {
 	deinit,
@@ -303,8 +309,52 @@ describe('test init', () => {
 					() => {
 						const documentLoadSpan = capturer.spans.find((span) => span.name === 'documentLoad')
 						expectDefined(documentLoadSpan, 'documentLoad span presence.')
-						expect(documentLoadSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 3000)
-						expect(documentLoadSpan).toHaveSpanAttribute('browser.navigation.status', 'timeout')
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
+							3000,
+						)
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+							PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+						)
+					},
+					{ timeout: 6000 },
+				)
+			} finally {
+				slowResourceAbortController.abort()
+			}
+		})
+
+		it('sets interrupted status on documentLoad span when page hides during PCT computation', async () => {
+			SplunkRum.init({
+				applicationName: 'my-app',
+				beaconEndpoint: 'https://127.0.0.1:9999/foo',
+				deploymentEnvironment: 'my-env',
+				globalAttributes: { customerType: 'GOLD' },
+				rumAccessToken: undefined,
+				spaMetrics: {
+					maxPageLoadWaitTime: 3000,
+					quietTime: 1000,
+				},
+				spanProcessors: [capturer],
+			})
+
+			const slowResourceAbortController = new AbortController()
+			void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+				signal: slowResourceAbortController.signal,
+			}).catch(() => {})
+
+			try {
+				window.dispatchEvent(new Event('pagehide'))
+
+				await vi.waitFor(
+					() => {
+						const documentLoadSpan = capturer.spans.find((span) => span.name === 'documentLoad')
+						expectDefined(documentLoadSpan, 'documentLoad span presence.')
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+							PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+						)
 					},
 					{ timeout: 6000 },
 				)
@@ -836,8 +886,40 @@ describe('test route change spa metrics timeout', () => {
 				() => {
 					const span = capturer.spans.find((s) => s.name === 'routeChange')
 					expectDefined(span, 'Check if routeChange span is present.')
-					expect(span).toHaveSpanAttribute('browser.navigation.page_completion_time', 3000)
-					expect(span).toHaveSpanAttribute('browser.navigation.status', 'timeout')
+					expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, 3000)
+					expect(span).toHaveSpanAttribute(
+						BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+						PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+					)
+					expect(span).toHaveSpanAttribute('prev.href', oldUrl)
+				},
+				{ timeout: 6000 },
+			)
+		} finally {
+			slowResourceAbortController.abort()
+		}
+	})
+
+	it('sets interrupted status on routeChange span when page hides during PCT computation', async () => {
+		const oldUrl = location.href
+		const slowResourceAbortController = new AbortController()
+		void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+			signal: slowResourceAbortController.signal,
+		}).catch(() => {})
+
+		try {
+			history.pushState({}, 'title', '/pctInterrupted#WithAHash')
+			window.dispatchEvent(new Event('pagehide'))
+
+			await vi.waitFor(
+				() => {
+					const span = capturer.spans.find((s) => s.name === 'routeChange')
+					expectDefined(span, 'Check if routeChange span is present.')
+					expect(span).toHaveSpanAttribute(
+						BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+						PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+					)
+					expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE)
 					expect(span).toHaveSpanAttribute('prev.href', oldUrl)
 				},
 				{ timeout: 6000 },


### PR DESCRIPTION
# Description

End PCT calculation when the document is being unloaded so pending document load and route change spans are still sent before the tab is closed or the page is navigated away from. If PCT calculation is interrupted by pagehide, the span is ended with `browser.navigation.status` set to `interrupted`.

<img width="508" height="132" alt="image" src="https://github.com/user-attachments/assets/554ce00d-05e6-4dba-85e4-ba287fe328fb" />

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
