### PR TITLE
feat: add commit-hash CDN release snapshots

### DIFF
--- a/scripts/release-cdn.mts
+++ b/scripts/release-cdn.mts
@@ -77,8 +77,9 @@ const cdnLinksByVersion: Record<string, string[]> = {}
 
 // Avoid accidental assets upload
 const allowedExtensions = ['.tgz', '.js', '.js.map', '.txt', '.html']
+const versions = await getAllVersions(targetVersion)
+const githubReleaseVersions = versions.filter(({ includeInGithubRelease }) => includeInGithubRelease !== false)
 const assets = await fs.readdir(ARTIFACTS_DIR)
-const versions = getAllVersions(targetVersion)
 versions.forEach((version) => {
 	cdnLinksByVersion[version.name] = []
 })
@@ -134,7 +135,7 @@ for (const asset of assets) {
 	}
 }
 
-const cdnLinks = generateCDNLinks(versions, cdnLinksByVersion)
+const cdnLinks = generateCDNLinks(githubReleaseVersions, cdnLinksByVersion)
 
 if (!isDryRun) {
 	console.log('Creating an invalidation to refresh shared versions.')

--- a/scripts/utils/cdn-snapshot-version.mts
+++ b/scripts/utils/cdn-snapshot-version.mts
@@ -1,0 +1,65 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { execSync } from 'node:child_process'
+import * as fs from 'node:fs/promises'
+
+import type { Version } from './versions.mjs'
+
+export const getCommitHash = () => {
+	try {
+		const commitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
+		if (!commitHash) {
+			throw new Error('Command returned an empty commit hash.')
+		}
+
+		return commitHash
+	} catch (error) {
+		throw new Error('Could not determine a commit hash for the CDN snapshot release.', { cause: error })
+	}
+}
+
+export const getPackageVersion = async () => {
+	const packageJson = JSON.parse(await fs.readFile('./package.json', 'utf8')) as { version?: string }
+	if (!packageJson.version) {
+		throw new Error('The root package.json does not define a version.')
+	}
+
+	return packageJson.version
+}
+
+export const createCdnSnapshotVersion = ({
+	commitHash,
+	packageVersion,
+}: {
+	commitHash: string
+	packageVersion: string
+}): Version => {
+	const versionPrefix = packageVersion.startsWith('v') ? packageVersion : `v${packageVersion}`
+
+	return {
+		includeInGithubRelease: false,
+		isVersionImmutable: true,
+		name: `${versionPrefix}-${commitHash}`,
+	}
+}
+
+export const getCdnSnapshotVersion = async () =>
+	createCdnSnapshotVersion({
+		commitHash: getCommitHash(),
+		packageVersion: await getPackageVersion(),
+	})

--- a/scripts/utils/cdn-snapshot-version.mts
+++ b/scripts/utils/cdn-snapshot-version.mts
@@ -22,7 +22,7 @@ import type { Version } from './versions.mjs'
 
 export const getCommitHash = () => {
 	try {
-		const commitHash = execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim()
+		const commitHash = execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim()
 		if (!commitHash) {
 			throw new Error('Command returned an empty commit hash.')
 		}

--- a/scripts/utils/index.mts
+++ b/scripts/utils/index.mts
@@ -16,6 +16,7 @@
  *
  */
 export * from './arguments.mjs'
+export * from './cdn-snapshot-version.mjs'
 export * from './cf-invalidation.mjs'
 export * from './generate-release-links.mjs'
 export * from './generate-script-snippet.mjs'

--- a/scripts/utils/versions.mts
+++ b/scripts/utils/versions.mts
@@ -15,14 +15,18 @@
  * limitations under the License.
  *
  */
+import { getCdnSnapshotVersion } from './cdn-snapshot-version.mjs'
+
 export interface Version {
+	includeInGithubRelease: boolean
 	isVersionImmutable: boolean
 	name: string
 }
 
-function* generateAllVersions(version: string): Generator<Version, void, unknown> {
+async function* generateAllVersions(version: string): AsyncGenerator<Version, void, unknown> {
 	if (version === 'main') {
-		yield { isVersionImmutable: false, name: 'next' }
+		yield await getCdnSnapshotVersion()
+		yield { includeInGithubRelease: false, isVersionImmutable: false, name: 'next' }
 		return
 	}
 
@@ -30,7 +34,7 @@ function* generateAllVersions(version: string): Generator<Version, void, unknown
 
 	let isVersionImmutable = true
 	while (versionParts.length > 0) {
-		yield { isVersionImmutable, name: `${versionParts.join('.')}` }
+		yield { includeInGithubRelease: true, isVersionImmutable, name: `${versionParts.join('.')}` }
 		const lastSegment = versionParts.pop()
 
 		if (lastSegment === undefined) {
@@ -46,4 +50,11 @@ function* generateAllVersions(version: string): Generator<Version, void, unknown
 	}
 }
 
-export const getAllVersions = (version: string) => Array.from(generateAllVersions(version))
+export const getAllVersions = async (version: string) => {
+	const versions: Version[] = []
+	for await (const generatedVersion of generateAllVersions(version)) {
+		versions.push(generatedVersion)
+	}
+
+	return versions
+}

--- a/scripts/utils/versions.test.node.ts
+++ b/scripts/utils/versions.test.node.ts
@@ -1,0 +1,60 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { describe, expect, it } from 'vitest'
+
+import { createCdnSnapshotVersion } from './cdn-snapshot-version.mjs'
+import { getAllVersions } from './versions.mjs'
+
+describe('getAllVersions', () => {
+	it('returns exact, minor, and major aliases for stable versions', async () => {
+		expect(await getAllVersions('v3.0.0')).toEqual([
+			{ includeInGithubRelease: true, isVersionImmutable: true, name: 'v3.0.0' },
+			{ includeInGithubRelease: true, isVersionImmutable: false, name: 'v3.0' },
+			{ includeInGithubRelease: true, isVersionImmutable: false, name: 'v3' },
+		])
+	})
+
+	it('returns the upload-only commit hash version before next for main', async () => {
+		expect(await getAllVersions('main')).toEqual([
+			{
+				includeInGithubRelease: false,
+				isVersionImmutable: true,
+				name: expect.stringMatching(/^v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/),
+			},
+			{ includeInGithubRelease: false, isVersionImmutable: false, name: 'next' },
+		])
+	})
+
+	it('creates an upload-only commit hash version', () => {
+		expect(createCdnSnapshotVersion({ commitHash: 'abc123', packageVersion: '3.0.0' })).toEqual({
+			includeInGithubRelease: false,
+			isVersionImmutable: true,
+			name: 'v3.0.0-abc123',
+		})
+	})
+
+	it('does not add the upload-only commit hash version before stable release aliases', async () => {
+		const versions = await getAllVersions('v3.0.0')
+
+		expect(versions).toEqual([
+			{ includeInGithubRelease: true, isVersionImmutable: true, name: 'v3.0.0' },
+			{ includeInGithubRelease: true, isVersionImmutable: false, name: 'v3.0' },
+			{ includeInGithubRelease: true, isVersionImmutable: false, name: 'v3' },
+		])
+	})
+})

--- a/scripts/utils/versions.test.node.ts
+++ b/scripts/utils/versions.test.node.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from 'vitest'
 import { createCdnSnapshotVersion } from './cdn-snapshot-version.mjs'
 import { getAllVersions } from './versions.mjs'
 
-const snapshotVersionNameRegex = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?-[0-9a-f]+$/
+const snapshotVersionNameRegex = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?-[0-9a-f]{40}$/
 
 describe('getAllVersions', () => {
 	it('returns exact, minor, and major aliases for stable versions', async () => {
@@ -57,26 +57,41 @@ describe('getAllVersions', () => {
 	})
 
 	it('creates an upload-only commit hash version', () => {
-		expect(createCdnSnapshotVersion({ commitHash: 'abc123', packageVersion: '3.0.0' })).toEqual({
+		expect(
+			createCdnSnapshotVersion({
+				commitHash: 'abc123def456abc123def456abc123def456abcd',
+				packageVersion: '3.0.0',
+			}),
+		).toEqual({
 			includeInGithubRelease: false,
 			isVersionImmutable: true,
-			name: 'v3.0.0-abc123',
+			name: 'v3.0.0-abc123def456abc123def456abc123def456abcd',
 		})
 	})
 
 	it('creates an upload-only commit hash version for beta packages', () => {
-		expect(createCdnSnapshotVersion({ commitHash: 'abc123', packageVersion: '3.1.0-beta.1' })).toEqual({
+		expect(
+			createCdnSnapshotVersion({
+				commitHash: 'abc123def456abc123def456abc123def456abcd',
+				packageVersion: '3.1.0-beta.1',
+			}),
+		).toEqual({
 			includeInGithubRelease: false,
 			isVersionImmutable: true,
-			name: 'v3.1.0-beta.1-abc123',
+			name: 'v3.1.0-beta.1-abc123def456abc123def456abc123def456abcd',
 		})
 	})
 
 	it('creates an upload-only commit hash version for alpha packages', () => {
-		expect(createCdnSnapshotVersion({ commitHash: 'abc123', packageVersion: '3.1.0-alpha.1' })).toEqual({
+		expect(
+			createCdnSnapshotVersion({
+				commitHash: 'abc123def456abc123def456abc123def456abcd',
+				packageVersion: '3.1.0-alpha.1',
+			}),
+		).toEqual({
 			includeInGithubRelease: false,
 			isVersionImmutable: true,
-			name: 'v3.1.0-alpha.1-abc123',
+			name: 'v3.1.0-alpha.1-abc123def456abc123def456abc123def456abcd',
 		})
 	})
 

--- a/scripts/utils/versions.test.node.ts
+++ b/scripts/utils/versions.test.node.ts
@@ -20,6 +20,8 @@ import { describe, expect, it } from 'vitest'
 import { createCdnSnapshotVersion } from './cdn-snapshot-version.mjs'
 import { getAllVersions } from './versions.mjs'
 
+const snapshotVersionNameRegex = /^v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?-[0-9a-f]+$/
+
 describe('getAllVersions', () => {
 	it('returns exact, minor, and major aliases for stable versions', async () => {
 		expect(await getAllVersions('v3.0.0')).toEqual([
@@ -34,9 +36,23 @@ describe('getAllVersions', () => {
 			{
 				includeInGithubRelease: false,
 				isVersionImmutable: true,
-				name: expect.stringMatching(/^v[0-9]+\.[0-9]+\.[0-9]+-[0-9a-f]+$/),
+				name: expect.stringMatching(snapshotVersionNameRegex),
 			},
 			{ includeInGithubRelease: false, isVersionImmutable: false, name: 'next' },
+		])
+	})
+
+	it('returns exact and beta aliases for beta versions', async () => {
+		expect(await getAllVersions('v3.1.0-beta.1')).toEqual([
+			{ includeInGithubRelease: true, isVersionImmutable: true, name: 'v3.1.0-beta.1' },
+			{ includeInGithubRelease: true, isVersionImmutable: false, name: 'v3.1.0-beta' },
+		])
+	})
+
+	it('returns exact and alpha aliases for alpha versions', async () => {
+		expect(await getAllVersions('v3.1.0-alpha.1')).toEqual([
+			{ includeInGithubRelease: true, isVersionImmutable: true, name: 'v3.1.0-alpha.1' },
+			{ includeInGithubRelease: true, isVersionImmutable: false, name: 'v3.1.0-alpha' },
 		])
 	})
 
@@ -45,6 +61,22 @@ describe('getAllVersions', () => {
 			includeInGithubRelease: false,
 			isVersionImmutable: true,
 			name: 'v3.0.0-abc123',
+		})
+	})
+
+	it('creates an upload-only commit hash version for beta packages', () => {
+		expect(createCdnSnapshotVersion({ commitHash: 'abc123', packageVersion: '3.1.0-beta.1' })).toEqual({
+			includeInGithubRelease: false,
+			isVersionImmutable: true,
+			name: 'v3.1.0-beta.1-abc123',
+		})
+	})
+
+	it('creates an upload-only commit hash version for alpha packages', () => {
+		expect(createCdnSnapshotVersion({ commitHash: 'abc123', packageVersion: '3.1.0-alpha.1' })).toEqual({
+			includeInGithubRelease: false,
+			isVersionImmutable: true,
+			name: 'v3.1.0-alpha.1-abc123',
 		})
 	})
 


### PR DESCRIPTION
# Description

Adds commit snapshot CDN releases for the `main` branch, publishing both an immutable commit-specific version and the mutable `next` alias.


## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
