### PR TITLE
chore: restore page completion changes

### DIFF
--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -15,9 +15,10 @@
  * limitations under the License.
  *
  */
+import { hrTimeToMilliseconds } from '@opentelemetry/core'
 import { expect } from '@playwright/test'
 
-import { test } from '../../utils/test'
+import { expectDefined, test } from '../../utils/test'
 import { timesMakeSense } from '../../utils/time-make-sense'
 
 test.describe('docload', () => {
@@ -153,6 +154,24 @@ test.describe('docload', () => {
 		)
 
 		expect(ignoredResourceFetchSpans).toHaveLength(0)
+	})
+
+	test('documentLoad span has docLoad duration on empty page', async ({ recordPage }) => {
+		await recordPage.goTo('/docload/docload-empty.ejs')
+
+		await recordPage.waitForSpans((spans) => spans.some((span) => span.name === 'documentLoad'))
+
+		const docLoadSpan = recordPage.receivedSpans.find((span) => span.name === 'documentLoad')
+		expectDefined(docLoadSpan)
+
+		const pct = Number(docLoadSpan.attributes['browser.navigation.page_completion_time'])
+		expect(pct).toBeGreaterThan(0)
+
+		// pct uses the same loadEventEnd - fetchStart calculation as the exported documentLoad span.
+		const durationMs = hrTimeToMilliseconds(docLoadSpan.duration)
+		// The span duration is serialized through OTLP HrTime and converted back to milliseconds,
+		// so equal browser timings can differ by a tiny floating-point rounding error.
+		expect(pct).toBeGreaterThanOrEqual(durationMs - 0.001)
 	})
 
 	test('module can be disabled', async ({ recordPage }) => {

--- a/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
+++ b/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
@@ -371,17 +371,13 @@ test.describe('web vitals', () => {
 
 		const lcp = recordPage.receivedSpans.filter((span) => span.attributes['lcp'] !== undefined)
 		const cls = recordPage.receivedSpans.filter((span) => span.attributes['cls'] !== undefined)
+		const webVitalsSpans = recordPage.receivedSpans.filter((span) => span.name === 'webvitals')
 
 		expect(lcp).toHaveLength(0)
 		expect(cls).toHaveLength(0)
-		expect(
-			recordPage.receivedSpans.some(
-				(span) =>
-					span.attributes['lcp.target'] !== undefined ||
-					span.attributes['cls.largest_shift_target'] !== undefined ||
-					Object.keys(span.attributes).some((key) => key.includes('.attribution.')),
-			),
-		).toBeFalsy()
+		for (const span of webVitalsSpans) {
+			expectNoAttributionTags(span)
+		}
 
 		expect(recordPage.receivedErrorSpans).toHaveLength(0)
 	})

--- a/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
+++ b/packages/integration-tests/src/tests/webvitals/webvitals.spec.ts
@@ -371,13 +371,17 @@ test.describe('web vitals', () => {
 
 		const lcp = recordPage.receivedSpans.filter((span) => span.attributes['lcp'] !== undefined)
 		const cls = recordPage.receivedSpans.filter((span) => span.attributes['cls'] !== undefined)
-		const webVitalsSpans = recordPage.receivedSpans.filter((span) => span.name === 'webvitals')
 
 		expect(lcp).toHaveLength(0)
 		expect(cls).toHaveLength(0)
-		for (const span of webVitalsSpans) {
-			expectNoAttributionTags(span)
-		}
+		expect(
+			recordPage.receivedSpans.some(
+				(span) =>
+					span.attributes['lcp.target'] !== undefined ||
+					span.attributes['cls.largest_shift_target'] !== undefined ||
+					Object.keys(span.attributes).some((key) => key.includes('.attribution.')),
+			),
+		).toBeFalsy()
 
 		expect(recordPage.receivedErrorSpans).toHaveLength(0)
 	})

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -29,7 +29,7 @@ import { Span } from '@opentelemetry/sdk-trace-base'
 import { addSpanNetworkEvents, PerformanceEntries, PerformanceTimingNames as PTN } from '@opentelemetry/sdk-trace-web'
 import { SemanticAttributes, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions'
 
-import { SessionManager } from '../managers'
+import { SessionManager, SpaMetricsManager } from '../managers'
 import { captureTraceParentFromPerformanceEntries } from '../servertiming'
 import { SplunkOtelWebConfig } from '../types'
 import { isCacheHit } from '../utils/cache'
@@ -74,24 +74,34 @@ type ExposedSuper = {
 }
 
 export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentation {
+	private readonly documentLoadMetricsPromise: ReturnType<SpaMetricsManager['waitForPageLoad']> | undefined
+
+	private readonly spaMetricsManager: SpaMetricsManager | undefined
+
 	constructor(
 		config: SplunkDocLoadInstrumentationConfig = {},
 		protected otelConfig: SplunkOtelWebConfig,
 		public sessionManager?: SessionManager,
+		spaMetricsManager?: SpaMetricsManager,
 	) {
 		super(config)
+		this.spaMetricsManager = spaMetricsManager
+		this.documentLoadMetricsPromise = this.spaMetricsManager?.waitForPageLoad({ startTime: 0 })
 
 		const exposedSuper = this as any as ExposedSuper
 
-		const _superEndSpan: ExposedSuper['_endSpan'] = exposedSuper._endSpan.bind(this)
 		const _superStartSpan: ExposedSuper['_startSpan'] = exposedSuper._startSpan.bind(this)
+		const _superEndSpan: ExposedSuper['_endSpan'] = exposedSuper._endSpan.bind(this)
 
 		exposedSuper._startSpan = (spanName, performanceName, entries, parentSpan) => {
 			const span = _superStartSpan(spanName, performanceName, entries, parentSpan)
-			if (span) {
-				// Upstream starts the span before this wrapper can set `component`, so SpanEmitterProcessor.onStart
-				// cannot route document-load start events. Emit manually once the component is present.
+
+			if (span && spanName === AttributeNames.DOCUMENT_LOAD) {
 				span.setAttribute('component', this.component)
+				addExtraDocLoadTags(span)
+				// The span processor's automatic onStart event already ran before
+				// `component` was set, so emit manually now that SpanEmitter can
+				// route this as `document-load:start`.
 				this.otelConfig.spanEmitter?.emitSpan(span, 'start')
 			}
 
@@ -145,6 +155,26 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 
 			if (span && exposedSpan.name === AttributeNames.DOCUMENT_LOAD) {
 				addExtraDocLoadTags(span)
+
+				if (this.documentLoadMetricsPromise) {
+					void this.documentLoadMetricsPromise
+						.then(({ pct, timeout }) => {
+							span.setAttribute('browser.navigation.page_completion_time', pct)
+							if (timeout) {
+								span.setAttribute('browser.navigation.status', 'timeout')
+							}
+
+							_superEndSpan(span, performanceName, entries)
+						})
+						.catch((error) => {
+							api.diag.warn('SplunkDocumentLoadInstrumentation: Failed to resolve page load metrics.', {
+								error,
+							})
+							_superEndSpan(span, performanceName, entries)
+						})
+
+					return
+				}
 			}
 
 			const result = _superEndSpan(span, performanceName, entries)

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -197,9 +197,14 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		if (this.spaMetricsManager) {
 			// Wait for all in-flight resources (XHR, fetch, media) to finish loading,
 			// then resolve after a quiet period with no new network activity.
-			const { pct } = await this.spaMetricsManager.waitForPageLoad({
+			const { pct, timeout } = await this.spaMetricsManager.waitForPageLoad({
 				startTime: performance.now(),
 			})
+
+			span.setAttribute('browser.navigation.page_completion_time', pct)
+			if (timeout) {
+				span.setAttribute('browser.navigation.status', 'timeout')
+			}
 
 			span.end(now + pct)
 			diag.debug('Route change span ended', { pct, span })

--- a/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.test.ts
@@ -76,10 +76,11 @@ describe('PerformanceMonitor', () => {
 		// Clean up
 		link.remove()
 
-		// Should have detected the CSS file
+		// Should have detected the CSS file (DISCOVERED then LOADED)
 		const cssEvents = events.filter((e) => e.url.includes('bootstrap'))
-		expect(cssEvents.length).toBeGreaterThan(0)
-		expect(cssEvents[0].state).toBe(ResourceState.LOADED)
+		expect(cssEvents.length).toBeGreaterThanOrEqual(2)
+		expect(cssEvents[0].state).toBe(ResourceState.DISCOVERED)
+		expect(cssEvents[1].state).toBe(ResourceState.LOADED)
 	})
 
 	it('ignores URLs matching ignore pattern', async () => {

--- a/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/performance-monitor.ts
@@ -81,11 +81,10 @@ export class PerformanceMonitor extends Monitor {
 
 		const loadTime = entry.responseEnd - entry.startTime
 
-		// We do not call DISCOVERED for now as it resets quiet timer
-		// this.config.onResourceStateChange({
-		// 	state: ResourceState.DISCOVERED,
-		// 	url,
-		// })
+		this.config.onResourceStateChange({
+			state: ResourceState.DISCOVERED,
+			url,
+		})
 
 		this.config.onResourceStateChange({
 			loadTime,

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
@@ -29,6 +29,7 @@ describe('QuietPeriodAwaiter', () => {
 
 		expect(result).toHaveProperty('pct')
 		expect(result.pct).toBe(10)
+		expect(result.timeout).toBe(false)
 	})
 
 	it('resets timer when removeQuietTimer is called', async () => {
@@ -43,6 +44,7 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 		expect(result.pct).toBeGreaterThanOrEqual(250)
 		expect(result.pct).toBeLessThan(300)
+		expect(result.timeout).toBe(false)
 	})
 
 	it('complete() resolves immediately', async () => {
@@ -51,5 +53,32 @@ describe('QuietPeriodAwaiter', () => {
 		awaiter.complete({ areResourcesStillLoading: false })
 		const result = await awaiter.promise
 		expect(result.pct).toBe(0)
+		expect(result.timeout).toBe(false)
+	})
+
+	it('resolves with timeout true when max page load wait time expires before quiet timer starts', async () => {
+		const startTime = performance.now()
+		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5, startTime })
+
+		const result = await awaiter.promise
+
+		expect(result.pct).toBe(10)
+		expect(result.timeout).toBe(true)
+	})
+
+	it('resolves only once when quiet period would expire after max page load wait time', async () => {
+		const results: unknown[] = []
+		const startTime = performance.now()
+		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 30, quietTime: 20, startTime })
+		void awaiter.promise.then((promiseResult) => results.push(promiseResult))
+
+		await new Promise((resolve) => setTimeout(resolve, 20))
+		awaiter.startQuietTimer({ resourceLoadedTimestamp: performance.now() })
+		const result = await awaiter.promise
+
+		await new Promise((resolve) => setTimeout(resolve, 50))
+		expect(result.pct).toBe(30)
+		expect(result.timeout).toBe(true)
+		expect(results).toHaveLength(1)
 	})
 })

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
@@ -18,13 +18,30 @@
 
 import { diag } from '@opentelemetry/api'
 
+const DEFAULT_MAX_PAGE_LOAD_WAIT_TIME = 180_000
 const DEFAULT_QUIET_TIME = 1000
 
-export type PageLoadMetricsResult = { pct: number }
+export type PageLoadMetricsResult = { pct: number; timeout: boolean }
 
 type QuietPeriodAwaiterConfig = {
+	maxPageLoadWaitTime?: number
 	quietTime?: number
 	startTime?: number
+}
+
+type MaxPageLoadWaitTimeConfig = Required<Pick<QuietPeriodAwaiterConfig, 'maxPageLoadWaitTime' | 'quietTime'>>
+
+export function normalizeMaxPageLoadWaitTime({ maxPageLoadWaitTime, quietTime }: MaxPageLoadWaitTimeConfig): number {
+	if (maxPageLoadWaitTime >= quietTime) {
+		return maxPageLoadWaitTime
+	}
+
+	diag.warn('spa.maxPageLoadWaitTime cannot be lower than quietTime. Using quietTime as maxPageLoadWaitTime.', {
+		maxPageLoadWaitTime,
+		quietTime,
+	})
+
+	return quietTime
 }
 
 export class QuietPeriodAwaiter {
@@ -34,19 +51,36 @@ export class QuietPeriodAwaiter {
 
 	private lastResourceTimestamp: number | undefined
 
+	private maxPageLoadWaitTime: number
+
+	private maxWaitTimeoutId: ReturnType<typeof setTimeout> | undefined
+
 	private quietTime: number
 
 	private startTime: number
 
 	private timeoutId: ReturnType<typeof setTimeout> | undefined
 
-	constructor({ quietTime = DEFAULT_QUIET_TIME, startTime = performance.now() }: QuietPeriodAwaiterConfig = {}) {
+	constructor({
+		maxPageLoadWaitTime = DEFAULT_MAX_PAGE_LOAD_WAIT_TIME,
+		quietTime = DEFAULT_QUIET_TIME,
+		startTime = performance.now(),
+	}: QuietPeriodAwaiterConfig = {}) {
 		this.startTime = startTime
 		this.quietTime = quietTime
+		this.maxPageLoadWaitTime = maxPageLoadWaitTime
 		this.promise = new Promise<PageLoadMetricsResult>((r) => {
 			// @ts-expect-error Readonly property for resolve
 			this.resolve = r
 		})
+		this.maxWaitTimeoutId = setTimeout(() => {
+			const pct = Math.max(this.maxPageLoadWaitTime, 0)
+			diag.debug('QuietPeriodAwaiter: Max page load wait time expired', { pct })
+			this.resolveOnce({
+				pct,
+				timeout: true,
+			})
+		}, maxPageLoadWaitTime)
 	}
 
 	complete({ areResourcesStillLoading }: { areResourcesStillLoading: boolean }): void {
@@ -64,6 +98,7 @@ export class QuietPeriodAwaiter {
 		diag.debug('QuietPeriodAwaiter: Complete', { pct })
 		this.resolveOnce({
 			pct,
+			timeout: false,
 		})
 	}
 
@@ -88,6 +123,7 @@ export class QuietPeriodAwaiter {
 			diag.debug('QuietPeriodAwaiter: Quiet period expired')
 			this.resolveOnce({
 				pct: Math.max(resourceLoadedTimestamp - this.startTime, 0),
+				timeout: false,
 			})
 		}, this.quietTime)
 	}
@@ -101,7 +137,9 @@ export class QuietPeriodAwaiter {
 
 		this.isResolved = true
 		clearTimeout(this.timeoutId)
+		clearTimeout(this.maxWaitTimeoutId)
 		this.timeoutId = undefined
+		this.maxWaitTimeoutId = undefined
 		this.resolve(resolveValue)
 	}
 }

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -16,8 +16,10 @@
  *
  */
 
-import { describe, expect, it } from 'vitest'
+import { diag } from '@opentelemetry/api'
+import { describe, expect, it, vi } from 'vitest'
 
+import { HTTP_TEST_SERVER_URL } from '../../../../../tests/servers/http-constants'
 import { ResourceState } from './monitors'
 import { getDocumentLoadTime, SpaMetricsManager } from './spa-metrics-manager'
 
@@ -29,6 +31,7 @@ describe('SpaMetricsManager', () => {
 		const config = manager.config
 
 		expect(config.quietTime).toBe(1000)
+		expect(config.maxPageLoadWaitTime).toBe(180_000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toEqual([])
 	})
@@ -36,6 +39,7 @@ describe('SpaMetricsManager', () => {
 	it('applies custom config', () => {
 		const manager = new SpaMetricsManager({
 			ignoreUrls: [/test/],
+			maxPageLoadWaitTime: 5000,
 			quietTime: 2000,
 		})
 
@@ -43,8 +47,26 @@ describe('SpaMetricsManager', () => {
 		const config = manager.config
 
 		expect(config.quietTime).toBe(2000)
+		expect(config.maxPageLoadWaitTime).toBe(5000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toHaveLength(1)
+	})
+
+	it('uses quiet time as max page load wait time and warns once when configured max is lower', () => {
+		const diagWarnSpy = vi.spyOn(diag, 'warn')
+		const manager = new SpaMetricsManager({ maxPageLoadWaitTime: 5, quietTime: 30 })
+
+		// @ts-expect-error Config is private. We use it for testing.
+		const config = manager.config
+
+		expect(config.maxPageLoadWaitTime).toBe(30)
+		expect(diagWarnSpy).toHaveBeenCalledTimes(1)
+		expect(diagWarnSpy).toHaveBeenCalledWith(
+			'spa.maxPageLoadWaitTime cannot be lower than quietTime. Using quietTime as maxPageLoadWaitTime.',
+			{ maxPageLoadWaitTime: 5, quietTime: 30 },
+		)
+
+		diagWarnSpy.mockRestore()
 	})
 
 	it('adds beacon endpoint origin to ignoreUrls', () => {
@@ -99,6 +121,7 @@ describe('SpaMetricsManager', () => {
 
 		const result = await promise
 		expect(result).toHaveProperty('pct')
+		expect(result.timeout).toBe(false)
 
 		manager.stop()
 	})
@@ -115,8 +138,29 @@ describe('SpaMetricsManager', () => {
 
 		expect(result.pct).toBeGreaterThanOrEqual(documentLoadTime)
 		expect(result.pct).toBeGreaterThan(0)
+		expect(result.timeout).toBe(false)
 
 		manager.stop()
+	})
+
+	it('waitForPageLoad resolves with timeout true when max page load wait time expires', async () => {
+		const manager = new SpaMetricsManager({ maxPageLoadWaitTime: 3000, quietTime: 1000 })
+		manager.start()
+		const slowResourceAbortController = new AbortController()
+
+		try {
+			const startTime = performance.now()
+			void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+				signal: slowResourceAbortController.signal,
+			}).catch(() => {})
+			const result = await manager.waitForPageLoad({ startTime })
+
+			expect(result.pct).toBe(3000)
+			expect(result.timeout).toBe(true)
+		} finally {
+			slowResourceAbortController.abort()
+			manager.stop()
+		}
 	})
 
 	it('tracks loading resources and manages quiet timer', () => {

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -19,10 +19,11 @@
 import { diag } from '@opentelemetry/api'
 
 import { FetchXhrMonitor, MediaMonitor, PerformanceMonitor, ResourceState, ResourceStateEvent } from './monitors'
-import { type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
+import { normalizeMaxPageLoadWaitTime, type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 const SPA_METRICS_MANAGER_CONFIG_DEFAULTS = {
 	ignoreUrls: [] as (string | RegExp)[],
+	maxPageLoadWaitTime: 180_000,
 	maxResourcesToWatch: 100,
 	quietTime: 1000,
 } as const
@@ -39,6 +40,7 @@ export function getDocumentLoadTime(navEntry: DocumentLoadTiming): number {
 export interface SpaMetricsManagerConfig {
 	beaconEndpoint?: string
 	ignoreUrls?: (string | RegExp)[]
+	maxPageLoadWaitTime?: number
 	maxResourcesToWatch?: number
 	quietTime?: number
 }
@@ -78,10 +80,13 @@ export class SpaMetricsManager {
 			}
 		}
 
+		const maxPageLoadWaitTime =
+			config.maxPageLoadWaitTime ?? SPA_METRICS_MANAGER_CONFIG_DEFAULTS.maxPageLoadWaitTime
 		const quietTime = config.quietTime ?? SPA_METRICS_MANAGER_CONFIG_DEFAULTS.quietTime
 
 		this.config = {
 			ignoreUrls,
+			maxPageLoadWaitTime: normalizeMaxPageLoadWaitTime({ maxPageLoadWaitTime, quietTime }),
 			maxResourcesToWatch: config.maxResourcesToWatch ?? SPA_METRICS_MANAGER_CONFIG_DEFAULTS.maxResourcesToWatch,
 			quietTime,
 		}
@@ -131,6 +136,7 @@ export class SpaMetricsManager {
 	waitForPageLoad({ startTime }: { startTime: number }): Promise<PageLoadMetricsResult> {
 		this.quietPeriodAwaiter?.complete({ areResourcesStillLoading: this.loadingResourcesCount > 0 })
 		this.quietPeriodAwaiter = new QuietPeriodAwaiter({
+			maxPageLoadWaitTime: this.config.maxPageLoadWaitTime,
 			quietTime: this.config.quietTime,
 			startTime,
 		})

--- a/packages/web/src/span-processors/span-emitter-processor.ts
+++ b/packages/web/src/span-processors/span-emitter-processor.ts
@@ -21,13 +21,8 @@ export type SpanEventType = string
 
 type SpanEventListener = (span: ReadableSpan) => void
 
-type BufferedSpanEvent = {
-	phase: 'end' | 'start'
-	span: ReadableSpan
-}
-
 export class SpanEmitterProcessor implements SpanProcessor {
-	private buffer: BufferedSpanEvent[] = []
+	private buffer: ReadableSpan[] = []
 
 	private isEnabled = false
 
@@ -61,8 +56,8 @@ export class SpanEmitterProcessor implements SpanProcessor {
 	enable() {
 		this.isEnabled = true
 
-		for (const { phase, span } of this.buffer) {
-			this.emitSpan(span, phase)
+		for (const span of this.buffer) {
+			this.emitSpan(span, 'end')
 		}
 
 		this.buffer = []
@@ -74,7 +69,7 @@ export class SpanEmitterProcessor implements SpanProcessor {
 
 	onEnd(span: ReadableSpan): void {
 		if (!this.isEnabled) {
-			this.buffer.push({ phase: 'end', span })
+			this.buffer.push(span)
 			return
 		}
 
@@ -83,7 +78,6 @@ export class SpanEmitterProcessor implements SpanProcessor {
 
 	onStart(span: ReadableSpan): void {
 		if (!this.isEnabled) {
-			this.buffer.push({ phase: 'start', span })
 			return
 		}
 

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -266,6 +266,7 @@ export interface SplunkOtelWebConfig {
 	 * // Enable with custom configuration
 	 * spaMetrics: {
 	 *   ignoreUrls: [/analytics\.example\.com/],
+	 *   maxPageLoadWaitTime: 180000,
 	 *   maxResourcesToWatch: 100,
 	 *   quietTime: 1000
 	 * }
@@ -279,6 +280,8 @@ export interface SplunkOtelWebConfig {
 		| {
 				/** URLs to exclude from PCT tracking (e.g., analytics, third-party scripts) */
 				ignoreUrls?: Array<string | RegExp>
+				/** Maximum time in milliseconds to wait for PCT computation before marking it as timed out. @default 180000 */
+				maxPageLoadWaitTime?: number
 				/** Maximum number of concurrent resources to track. @default 100 */
 				maxResourcesToWatch?: number
 				/** Time in milliseconds to wait after last resource loads before considering page complete. @default 1000 */

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -21,6 +21,7 @@ import * as tracing from '@opentelemetry/sdk-trace-base'
 import { expectDefined } from '@test-utils/assertions'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { HTTP_TEST_SERVER_URL } from '../../../tests/servers/http-constants'
 import SplunkRum from '../src'
 import { VERSION } from '../src/version'
 import {
@@ -276,6 +277,40 @@ describe('test init', () => {
 
 			const resourceFetchSpan = capturer.spans.find((span) => span.name === 'resourceFetch')
 			expectDefined(resourceFetchSpan, 'resourceFetch span presence.')
+		})
+
+		it('sets timeout status on documentLoad span when PCT computation times out', async () => {
+			SplunkRum.init({
+				applicationName: 'my-app',
+				beaconEndpoint: 'https://127.0.0.1:9999/foo',
+				deploymentEnvironment: 'my-env',
+				globalAttributes: { customerType: 'GOLD' },
+				rumAccessToken: undefined,
+				spaMetrics: {
+					maxPageLoadWaitTime: 3000,
+					quietTime: 1000,
+				},
+				spanProcessors: [capturer],
+			})
+
+			const slowResourceAbortController = new AbortController()
+			void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+				signal: slowResourceAbortController.signal,
+			}).catch(() => {})
+
+			try {
+				await vi.waitFor(
+					() => {
+						const documentLoadSpan = capturer.spans.find((span) => span.name === 'documentLoad')
+						expectDefined(documentLoadSpan, 'documentLoad span presence.')
+						expect(documentLoadSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 3000)
+						expect(documentLoadSpan).toHaveSpanAttribute('browser.navigation.status', 'timeout')
+					},
+					{ timeout: 6000 },
+				)
+			} finally {
+				slowResourceAbortController.abort()
+			}
 		})
 	})
 	describe('double-init has no effect', () => {
@@ -766,6 +801,50 @@ describe('test route change', () => {
 		expect(span).toHaveSpanAttributeContaining('location.href', '#hashChange')
 		expect(span).toHaveSpanAttribute('prev.href', oldUrl)
 		history.pushState({}, 'title', '/')
+	})
+})
+
+describe('test route change spa metrics timeout', () => {
+	let capturer: SpanCapturer
+
+	beforeEach(() => {
+		capturer = new SpanCapturer()
+		initWithDefaultConfig(capturer, {
+			spaMetrics: {
+				maxPageLoadWaitTime: 3000,
+				quietTime: 1000,
+			},
+		})
+	})
+
+	afterEach(() => {
+		deinit()
+		history.pushState({}, 'title', '/')
+	})
+
+	it('sets timeout status on routeChange span when PCT computation times out', async () => {
+		const oldUrl = location.href
+		const slowResourceAbortController = new AbortController()
+		void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+			signal: slowResourceAbortController.signal,
+		}).catch(() => {})
+
+		try {
+			history.pushState({}, 'title', '/pctTimeout#WithAHash')
+
+			await vi.waitFor(
+				() => {
+					const span = capturer.spans.find((s) => s.name === 'routeChange')
+					expectDefined(span, 'Check if routeChange span is present.')
+					expect(span).toHaveSpanAttribute('browser.navigation.page_completion_time', 3000)
+					expect(span).toHaveSpanAttribute('browser.navigation.status', 'timeout')
+					expect(span).toHaveSpanAttribute('prev.href', oldUrl)
+				},
+				{ timeout: 6000 },
+			)
+		} finally {
+			slowResourceAbortController.abort()
+		}
 	})
 })
 


### PR DESCRIPTION
# Description

 - Restores page completion time reporting on documentLoad and routeChange spans.
 - Adds timeout status reporting via `browser.navigation.status`.
 - Restores performance monitor `DISCOVERED` resource state emission.

