### PR TITLE
fix: preserve captured URL on route change spans

### DIFF
--- a/packages/integration-tests/src/tests/user-interaction/history.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/history.spec.ts
@@ -41,6 +41,28 @@ test.describe('history', () => {
 		expect(recordPage.receivedErrorSpans).toHaveLength(0)
 	})
 
+	test('handles quick hash changes', async ({ recordPage }) => {
+		const url = 'http://localhost:3000/user-interaction/history.ejs'
+		await recordPage.goTo('/user-interaction/history.ejs')
+
+		await recordPage.evaluate(() => {
+			location.hash = '#a'
+			location.hash = '#b'
+		})
+
+		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'routeChange').length === 2)
+		const navigationSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
+
+		expect(navigationSpans).toHaveLength(2)
+		expect(navigationSpans[0]).toHaveSpanAttribute('component', 'user-interaction')
+		expect(navigationSpans[0]).toHaveSpanAttribute('prev.href', url)
+		expect(navigationSpans[0]).toHaveSpanAttribute('location.href', `${url}#a`)
+		expect(navigationSpans[1]).toHaveSpanAttribute('component', 'user-interaction')
+		expect(navigationSpans[1]).toHaveSpanAttribute('prev.href', `${url}#a`)
+		expect(navigationSpans[1]).toHaveSpanAttribute('location.href', `${url}#b`)
+		expect(recordPage.receivedErrorSpans).toHaveLength(0)
+	})
+
 	test('handles history navigation', async ({ recordPage }) => {
 		await recordPage.goTo('/user-interaction/history.ejs')
 

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -152,7 +152,7 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 				const result = original.apply(this, args)
 				const newHref = location.href
 				if (oldHref !== newHref) {
-					void that._emitRouteChangeSpan(oldHref)
+					void that._emitRouteChangeSpan(oldHref, newHref)
 				}
 
 				return result
@@ -168,7 +168,8 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 
 	enable(): void {
 		this.__hashChangeHandler = (event: Event) => {
-			void this._emitRouteChangeSpan((event as HashChangeEvent).oldURL)
+			const hashChangeEvent = event as HashChangeEvent
+			void this._emitRouteChangeSpan(hashChangeEvent.oldURL, hashChangeEvent.newURL)
 		}
 
 		// Hash can be changed with location.hash = '#newThing', no way to hook that directly...
@@ -187,17 +188,17 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		this._routingTracer = tracerProvider.getTracer(ROUTING_INSTRUMENTATION_NAME, ROUTING_INSTRUMENTATION_VERSION)
 	}
 
-	private async _emitRouteChangeSpan(oldHref: string) {
+	private async _emitRouteChangeSpan(oldHref: string, newHref: string) {
 		const config = this.getConfig()
-		if (isUrlIgnored(location.href, config.ignoreUrls)) {
+		if (isUrlIgnored(newHref, config.ignoreUrls)) {
 			return
 		}
 
 		const now = Date.now()
 		const span = this._routingTracer.startSpan('routeChange', { startTime: now })
 		span.setAttribute('component', this.moduleName)
+		span.setAttribute('location.href', newHref)
 		span.setAttribute('prev.href', oldHref)
-		// location.href set with new value by default
 
 		if (this.spaMetricsManager) {
 			// Wait for all in-flight resources (XHR, fetch, media) to finish loading,

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
@@ -22,8 +22,9 @@ import { QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 describe('QuietPeriodAwaiter', () => {
 	it('resolves after quiet period expires', async () => {
-		const awaiter = new QuietPeriodAwaiter({ quietTime: 100 })
-		const resourceLoadedTimestamp = performance.now() + 10
+		const startTime = performance.now()
+		const awaiter = new QuietPeriodAwaiter({ quietTime: 100, startTime })
+		const resourceLoadedTimestamp = startTime + 10
 		awaiter.startQuietTimer({ resourceLoadedTimestamp })
 
 		const result = await awaiter.promise

--- a/packages/web/src/span-processors/span-attributes-processor.ts
+++ b/packages/web/src/span-processors/span-attributes-processor.ts
@@ -65,7 +65,10 @@ export class SpanAttributesProcessor implements SpanProcessor {
 	}
 
 	onStart(span: Span): void {
-		span.setAttribute('location.href', location.href)
+		if (span.attributes['location.href'] === undefined) {
+			span.setAttribute('location.href', location.href)
+		}
+
 		span.setAttributes(this._globalAttributes)
 
 		const sessionState = this.sessionManager.getSessionState()

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -852,6 +852,28 @@ describe('test route change', () => {
 		expect(span).toHaveSpanAttribute('prev.href', oldUrl)
 		history.pushState({}, 'title', '/')
 	})
+
+	it('should capture consecutive location.hash changes with correct previous and current URLs', async () => {
+		history.replaceState({}, 'title', '/')
+		const oldUrl = location.href
+		capturer.clear()
+
+		location.hash = '#a'
+		location.hash = '#b'
+
+		await vi.waitFor(() => {
+			const spans_ = capturer.spans.filter((s) => s.name === 'routeChange')
+			expect(spans_).toHaveLength(2)
+		})
+
+		const spans = capturer.spans.filter((s) => s.name === 'routeChange')
+		expect(spans[0]).toHaveSpanAttribute('prev.href', oldUrl)
+		expect(spans[0]).toHaveSpanAttribute('location.href', `${oldUrl}#a`)
+		expect(spans[1]).toHaveSpanAttribute('prev.href', `${oldUrl}#a`)
+		expect(spans[1]).toHaveSpanAttribute('location.href', `${oldUrl}#b`)
+
+		history.replaceState({}, 'title', '/')
+	})
 })
 
 describe('test route change spa metrics timeout', () => {
@@ -1173,13 +1195,14 @@ describe('external session handling', () => {
 
 	it('should not create session.start span for external sessions', async () => {
 		const now = Date.now()
+		const sessionStart = now - performance.now()
 
 		window.SplunkRumExternal = {
 			getSessionMetadata: vi.fn().mockReturnValue({
 				anonymousUserId: 'external-anon-id-123',
 				sessionId: 'external-session-id-123',
 				sessionLastActivity: now,
-				sessionStart: now - 1000,
+				sessionStart,
 			}),
 		}
 

--- a/packages/web/tests/splunk-span-attributes-processor.test.ts
+++ b/packages/web/tests/splunk-span-attributes-processor.test.ts
@@ -16,6 +16,7 @@
  *
  */
 
+import type { Span } from '@opentelemetry/sdk-trace-base'
 import { describe, expect, it } from 'vitest'
 
 import { SessionManager, StorageManager, UserManager } from '../src/managers'
@@ -55,6 +56,27 @@ describe('SplunkSpanAttributesProcessor', () => {
 				key2: 'value2-updated',
 				key3: 'value3',
 			})
+		})
+
+		it('does not overwrite an existing location.href attribute on span start', () => {
+			const processor = new SpanAttributesProcessor(sessionManager, userManager, {}, true, false)
+			const attributes: Record<string, unknown> = {
+				'location.href': 'https://example.com/captured-route',
+			}
+			const span = {
+				attributes,
+				resource: { attributes: {} },
+				setAttribute: (key: string, value: unknown) => {
+					attributes[key] = value
+				},
+				setAttributes: (values: Record<string, unknown>) => {
+					Object.assign(attributes, values)
+				},
+			}
+
+			processor.onStart(span as unknown as Span)
+
+			expect(attributes['location.href']).toBe('https://example.com/captured-route')
 		})
 	})
 })


### PR DESCRIPTION
# Description

Fix route change URL attribution when multiple hash changes happen before `hashchange` handlers run.

## Type of change

Delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)


# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
