### PR TITLE
chore: mark completed browser navigations

### DIFF
--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
@@ -121,6 +121,6 @@ test.describe('spa-metrics', () => {
 
 		expect(overrideConfigSpan).toHaveSpanAttributeContaining('location.href', '#network-disabled')
 		expect(overrideConfigSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 0)
-		expect(overrideConfigSpan).toNotHaveSpanAttribute('browser.navigation.status')
+		expect(overrideConfigSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
 	})
 })

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -167,9 +167,7 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 					void this.documentLoadMetricsPromise
 						.then(({ pct, status }) => {
 							span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
-							if (status) {
-								span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
-							}
+							span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
 
 							api.diag.debug('Sending documentLoad span with PCT result', {
 								pct,

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -208,9 +208,7 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 			})
 
 			span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
-			if (status) {
-				span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
-			}
+			span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
 
 			diag.debug('Sending routeChange span with PCT result', {
 				pct,

--- a/packages/web/src/managers/spa-metrics-manager/constants.ts
+++ b/packages/web/src/managers/spa-metrics-manager/constants.ts
@@ -19,5 +19,6 @@
 export const BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE = 'browser.navigation.page_completion_time'
 export const BROWSER_NAVIGATION_STATUS_ATTRIBUTE = 'browser.navigation.status'
 
+export const PAGE_LOAD_METRICS_STATUS_COMPLETED = 'completed'
 export const PAGE_LOAD_METRICS_STATUS_INTERRUPTED = 'interrupted'
 export const PAGE_LOAD_METRICS_STATUS_TIMEOUT = 'timeout'

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
@@ -17,7 +17,11 @@
  */
 import { describe, expect, it } from 'vitest'
 
-import { PAGE_LOAD_METRICS_STATUS_INTERRUPTED, PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
+import {
+	PAGE_LOAD_METRICS_STATUS_COMPLETED,
+	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+} from './constants'
 import { QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 describe('QuietPeriodAwaiter', () => {
@@ -31,7 +35,7 @@ describe('QuietPeriodAwaiter', () => {
 
 		expect(result).toHaveProperty('pct')
 		expect(result.pct).toBe(10)
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 	})
 
 	it('resets timer when removeQuietTimer is called', async () => {
@@ -46,7 +50,7 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 		expect(result.pct).toBeGreaterThanOrEqual(250)
 		expect(result.pct).toBeLessThan(300)
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 	})
 
 	it('keeps the latest resource timestamp when quiet timers are started out of order', async () => {
@@ -58,7 +62,7 @@ describe('QuietPeriodAwaiter', () => {
 
 		const result = await awaiter.promise
 		expect(result.pct).toBe(500)
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 	})
 
 	it('complete() resolves immediately', async () => {
@@ -68,7 +72,7 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 		expect(result.pct).toBeGreaterThanOrEqual(0)
 		expect(result.pct).toBeLessThan(1000)
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 	})
 
 	it('interrupt() resolves immediately with interrupted status', async () => {

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
@@ -18,7 +18,11 @@
 
 import { diag } from '@opentelemetry/api'
 
-import { PAGE_LOAD_METRICS_STATUS_INTERRUPTED, PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
+import {
+	PAGE_LOAD_METRICS_STATUS_COMPLETED,
+	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+} from './constants'
 
 const DEFAULT_MAX_PAGE_LOAD_WAIT_TIME = 180_000
 const DEFAULT_QUIET_TIME = 1000
@@ -26,12 +30,13 @@ const INTERRUPT_LISTENER_OPTIONS: AddEventListenerOptions = { capture: true, onc
 const INTERRUPT_LISTENER_REMOVE_OPTIONS: EventListenerOptions = { capture: true }
 
 export type PageLoadMetricsStatus =
+	| typeof PAGE_LOAD_METRICS_STATUS_COMPLETED
 	| typeof PAGE_LOAD_METRICS_STATUS_INTERRUPTED
 	| typeof PAGE_LOAD_METRICS_STATUS_TIMEOUT
 
 export type PageLoadMetricsResult = {
 	pct: number
-	status?: PageLoadMetricsStatus
+	status: PageLoadMetricsStatus
 }
 
 type QuietPeriodAwaiterConfig = {
@@ -110,6 +115,7 @@ export class QuietPeriodAwaiter {
 		diag.debug('QuietPeriodAwaiter: Complete', { pct })
 		this.resolveOnce({
 			pct,
+			status: PAGE_LOAD_METRICS_STATUS_COMPLETED,
 		})
 	}
 
@@ -152,6 +158,7 @@ export class QuietPeriodAwaiter {
 			diag.debug('QuietPeriodAwaiter: Quiet period expired', this.quietTime)
 			this.resolveOnce({
 				pct: Math.max(quietPeriodTimestamp - this.startTime, 0),
+				status: PAGE_LOAD_METRICS_STATUS_COMPLETED,
 			})
 		}, this.quietTime)
 	}

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -20,7 +20,11 @@ import { diag } from '@opentelemetry/api'
 import { describe, expect, it, vi } from 'vitest'
 
 import { HTTP_TEST_SERVER_URL } from '../../../../../tests/servers/http-constants'
-import { PAGE_LOAD_METRICS_STATUS_INTERRUPTED, PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
+import {
+	PAGE_LOAD_METRICS_STATUS_COMPLETED,
+	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+} from './constants'
 import { ResourceState } from './monitors'
 import { getDocumentLoadTime, SpaMetricsManager } from './spa-metrics-manager'
 
@@ -327,7 +331,7 @@ describe('SpaMetricsManager', () => {
 
 		const result = await promise
 		expect(result).toHaveProperty('pct')
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 
 		manager.stop()
 	})
@@ -344,7 +348,7 @@ describe('SpaMetricsManager', () => {
 
 		expect(result.pct).toBeGreaterThanOrEqual(documentLoadTime)
 		expect(result.pct).toBeGreaterThan(0)
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 
 		manager.stop()
 	})
@@ -717,7 +721,7 @@ describe('SpaMetricsManager', () => {
 		expect(manager.loadingResources.size).toBe(0)
 
 		const result = await promise
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 	})
 
 	it('keeps resources discovered on the current page before waitForPageLoad starts', async () => {
@@ -749,7 +753,7 @@ describe('SpaMetricsManager', () => {
 		})
 
 		const result = await promise
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 
 		// @ts-expect-error loadingResources is private. We use it for testing.
 		expect(manager.loadingResources.size).toBe(0)
@@ -789,7 +793,7 @@ describe('SpaMetricsManager', () => {
 		})
 
 		const result = await promise
-		expect(result.status).toBeUndefined()
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
 
 		// @ts-expect-error loadingResources is private. We use it for testing.
 		expect(manager.loadingResources.size).toBe(0)

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -26,6 +26,7 @@ import SplunkRum from '../src'
 import {
 	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+	PAGE_LOAD_METRICS_STATUS_COMPLETED,
 	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
 	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
 } from '../src/managers'
@@ -295,6 +296,11 @@ describe('test init', () => {
 
 			const documentLoadSpan = capturer.spans.find((span) => span.name === 'documentLoad')
 			expectDefined(documentLoadSpan, 'documentLoad span presence.')
+			expect(documentLoadSpan).toHaveSpanAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE)
+			expect(documentLoadSpan).toHaveSpanAttribute(
+				BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+				PAGE_LOAD_METRICS_STATUS_COMPLETED,
+			)
 			expect(documentLoadSpan).toHaveSpanAttributeMatching('screen.xy', /^[0-9]+x[0-9]+$/)
 
 			const resourceFetchSpan = capturer.spans.find((span) => span.name === 'resourceFetch')
@@ -908,6 +914,26 @@ describe('test route change spa metrics timeout', () => {
 	afterEach(() => {
 		deinit()
 		history.pushState({}, 'title', '/')
+	})
+
+	it('sets completed status on routeChange span when PCT computation completes', async () => {
+		const oldUrl = location.href
+
+		history.pushState({}, 'title', '/pctCompleted#WithAHash')
+
+		await vi.waitFor(
+			() => {
+				const span = capturer.spans.find((s) => s.name === 'routeChange')
+				expectDefined(span, 'Check if routeChange span is present.')
+				expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE)
+				expect(span).toHaveSpanAttribute(
+					BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+					PAGE_LOAD_METRICS_STATUS_COMPLETED,
+				)
+				expect(span).toHaveSpanAttribute('prev.href', oldUrl)
+			},
+			{ timeout: 6000 },
+		)
 	})
 
 	it('sets timeout status on routeChange span when PCT computation times out', async () => {


### PR DESCRIPTION
# Description

Add `completed` as a `browser.navigation.status` value for successful docLoad and routeChange spans


## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
