### PR TITLE
chore: report loading resources on interrupted navigations

### DIFF
--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
@@ -117,6 +117,11 @@ test.describe('spa-metrics', () => {
 
 		expect(globalConfigSpan).toHaveSpanAttributeContaining('location.href', '#slow-fetch')
 		expect(globalConfigSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 1000)
+		expect(globalConfigSpan).toHaveSpanAttribute('browser.navigation.loading_resource_count', 1)
+		expect(globalConfigSpan).toHaveSpanAttribute(
+			'browser.navigation.loading_resource_urls',
+			JSON.stringify(['/some-data?delay=1500&resource=global-slow-fetch']),
+		)
 		expect(globalConfigSpan).toHaveSpanAttribute('browser.navigation.status', 'timeout')
 
 		expect(overrideConfigSpan).toHaveSpanAttributeContaining('location.href', '#network-disabled')

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -30,6 +30,8 @@ import { addSpanNetworkEvents, PerformanceEntries, PerformanceTimingNames as PTN
 import { SemanticAttributes, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions'
 
 import {
+	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
 	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 	SessionManager,
@@ -165,11 +167,25 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 
 				if (this.documentLoadMetricsPromise) {
 					void this.documentLoadMetricsPromise
-						.then(({ pct, status }) => {
+						.then(({ loadingResourcesCount, loadingResourceUrls, pct, status }) => {
 							span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
 							span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
+							if (loadingResourcesCount > 0) {
+								span.setAttribute(
+									BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
+									loadingResourcesCount,
+								)
+								if (loadingResourceUrls.length > 0) {
+									span.setAttribute(
+										BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+										JSON.stringify(loadingResourceUrls),
+									)
+								}
+							}
 
 							api.diag.debug('Sending documentLoad span with PCT result', {
+								loadingResourcesCount,
+								loadingResourceUrls,
 								pct,
 								status,
 							})

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -20,6 +20,8 @@ import { diag, Span, trace, Tracer, TracerProvider } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
 import {
+	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
 	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 	SessionManager,
@@ -203,14 +205,26 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		if (this.spaMetricsManager) {
 			// Wait for all in-flight resources (XHR, fetch, media) to finish loading,
 			// then resolve after a quiet period with no new network activity.
-			const { pct, status } = await this.spaMetricsManager.waitForPageLoad({
-				startTime: performance.now(),
-			})
+			const { loadingResourcesCount, loadingResourceUrls, pct, status } =
+				await this.spaMetricsManager.waitForPageLoad({
+					startTime: performance.now(),
+				})
 
 			span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
 			span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
+			if (loadingResourcesCount > 0) {
+				span.setAttribute(BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE, loadingResourcesCount)
+				if (loadingResourceUrls.length > 0) {
+					span.setAttribute(
+						BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+						JSON.stringify(loadingResourceUrls),
+					)
+				}
+			}
 
 			diag.debug('Sending routeChange span with PCT result', {
+				loadingResourcesCount,
+				loadingResourceUrls,
 				pct,
 				status,
 			})

--- a/packages/web/src/managers/spa-metrics-manager/constants.ts
+++ b/packages/web/src/managers/spa-metrics-manager/constants.ts
@@ -16,6 +16,8 @@
  *
  */
 
+export const BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE = 'browser.navigation.loading_resource_count'
+export const BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE = 'browser.navigation.loading_resource_urls'
 export const BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE = 'browser.navigation.page_completion_time'
 export const BROWSER_NAVIGATION_STATUS_ATTRIBUTE = 'browser.navigation.status'
 

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
@@ -22,12 +22,32 @@ import {
 	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
 	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
 } from './constants'
-import { QuietPeriodAwaiter } from './quiet-period-awaiter'
+import { type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
+
+type QuietPeriodAwaiterTestConfig = Omit<
+	ConstructorParameters<typeof QuietPeriodAwaiter>[0],
+	'getLoadingResourceUrls' | 'getLoadingResourcesCount'
+>
+
+function createQuietPeriodAwaiter(config: QuietPeriodAwaiterTestConfig = {}): QuietPeriodAwaiter {
+	return new QuietPeriodAwaiter({
+		getLoadingResourcesCount: () => 0,
+		getLoadingResourceUrls: () => [],
+		maxPageLoadWaitTime: config.maxPageLoadWaitTime,
+		quietTime: config.quietTime,
+		startTime: config.startTime,
+	})
+}
+
+function expectNoLoadingResources(result: PageLoadMetricsResult): void {
+	expect(result.loadingResourcesCount).toBe(0)
+	expect(result.loadingResourceUrls).toEqual([])
+}
 
 describe('QuietPeriodAwaiter', () => {
 	it('resolves after quiet period expires', async () => {
 		const startTime = performance.now()
-		const awaiter = new QuietPeriodAwaiter({ quietTime: 100, startTime })
+		const awaiter = createQuietPeriodAwaiter({ quietTime: 100, startTime })
 		const resourceLoadedTimestamp = startTime + 10
 		awaiter.startQuietTimer({ resourceLoadedTimestamp })
 
@@ -36,10 +56,11 @@ describe('QuietPeriodAwaiter', () => {
 		expect(result).toHaveProperty('pct')
 		expect(result.pct).toBe(10)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expectNoLoadingResources(result)
 	})
 
 	it('resets timer when removeQuietTimer is called', async () => {
-		const awaiter = new QuietPeriodAwaiter({ quietTime: 500 })
+		const awaiter = createQuietPeriodAwaiter({ quietTime: 500 })
 		awaiter.startQuietTimer({ resourceLoadedTimestamp: performance.now() })
 
 		await new Promise((resolve) => setTimeout(resolve, 250))
@@ -51,10 +72,11 @@ describe('QuietPeriodAwaiter', () => {
 		expect(result.pct).toBeGreaterThanOrEqual(250)
 		expect(result.pct).toBeLessThan(300)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expectNoLoadingResources(result)
 	})
 
 	it('keeps the latest resource timestamp when quiet timers are started out of order', async () => {
-		const awaiter = new QuietPeriodAwaiter({ quietTime: 10, startTime: 1000 })
+		const awaiter = createQuietPeriodAwaiter({ quietTime: 10, startTime: 1000 })
 
 		awaiter.startQuietTimer({ resourceLoadedTimestamp: 1500 })
 		awaiter.removeQuietTimer()
@@ -63,20 +85,22 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 		expect(result.pct).toBe(500)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expectNoLoadingResources(result)
 	})
 
 	it('complete() resolves immediately', async () => {
-		const awaiter = new QuietPeriodAwaiter({ quietTime: 1000 })
+		const awaiter = createQuietPeriodAwaiter({ quietTime: 1000 })
 
 		awaiter.complete({ areResourcesStillLoading: false })
 		const result = await awaiter.promise
 		expect(result.pct).toBeGreaterThanOrEqual(0)
 		expect(result.pct).toBeLessThan(1000)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expectNoLoadingResources(result)
 	})
 
 	it('interrupt() resolves immediately with interrupted status', async () => {
-		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
+		const awaiter = createQuietPeriodAwaiter({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
 		awaiter.startQuietTimer({ resourceLoadedTimestamp: performance.now() + 100 })
 
 		awaiter.interrupt()
@@ -84,10 +108,26 @@ describe('QuietPeriodAwaiter', () => {
 
 		expect(result.pct).toBeGreaterThanOrEqual(0)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		expectNoLoadingResources(result)
+	})
+
+	it('uses empty loading resource URLs when loading resource count is zero', async () => {
+		const awaiter = new QuietPeriodAwaiter({
+			getLoadingResourcesCount: () => 0,
+			getLoadingResourceUrls: () => ['https://example.test/resource.js'],
+			maxPageLoadWaitTime: 5000,
+			quietTime: 1000,
+		})
+
+		awaiter.interrupt()
+		const result = await awaiter.promise
+
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		expectNoLoadingResources(result)
 	})
 
 	it('resolves with interrupted status when persisted pagehide fires', async () => {
-		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
+		const awaiter = createQuietPeriodAwaiter({ maxPageLoadWaitTime: 5000, quietTime: 1000 })
 		const event = new Event('pagehide') as PageTransitionEvent
 		Object.defineProperty(event, 'persisted', { value: true })
 
@@ -95,31 +135,34 @@ describe('QuietPeriodAwaiter', () => {
 
 		const result = await awaiter.promise
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		expectNoLoadingResources(result)
 	})
 
 	it('does not resolve with interrupted status when beforeunload fires', async () => {
-		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5 })
+		const awaiter = createQuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5 })
 
 		window.dispatchEvent(new Event('beforeunload'))
 
 		const result = await awaiter.promise
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+		expectNoLoadingResources(result)
 	})
 
 	it('resolves with timeout status when max page load wait time expires before quiet timer starts', async () => {
 		const startTime = performance.now()
-		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5, startTime })
+		const awaiter = createQuietPeriodAwaiter({ maxPageLoadWaitTime: 10, quietTime: 5, startTime })
 
 		const result = await awaiter.promise
 
 		expect(result.pct).toBe(10)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+		expectNoLoadingResources(result)
 	})
 
 	it('resolves only once when quiet period would expire after max page load wait time', async () => {
 		const results: unknown[] = []
 		const startTime = performance.now()
-		const awaiter = new QuietPeriodAwaiter({ maxPageLoadWaitTime: 30, quietTime: 20, startTime })
+		const awaiter = createQuietPeriodAwaiter({ maxPageLoadWaitTime: 30, quietTime: 20, startTime })
 		void awaiter.promise.then((promiseResult) => results.push(promiseResult))
 
 		await new Promise((resolve) => setTimeout(resolve, 20))
@@ -129,6 +172,7 @@ describe('QuietPeriodAwaiter', () => {
 		await new Promise((resolve) => setTimeout(resolve, 50))
 		expect(result.pct).toBe(30)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+		expectNoLoadingResources(result)
 		expect(results).toHaveLength(1)
 	})
 })

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
@@ -35,11 +35,17 @@ export type PageLoadMetricsStatus =
 	| typeof PAGE_LOAD_METRICS_STATUS_TIMEOUT
 
 export type PageLoadMetricsResult = {
+	loadingResourceUrls: string[]
+	loadingResourcesCount: number
 	pct: number
 	status: PageLoadMetricsStatus
 }
 
+type PageLoadMetricsResolveValue = Omit<PageLoadMetricsResult, 'loadingResourcesCount' | 'loadingResourceUrls'>
+
 type QuietPeriodAwaiterConfig = {
+	getLoadingResourceUrls: () => string[]
+	getLoadingResourcesCount: () => number
 	maxPageLoadWaitTime?: number
 	quietTime?: number
 	startTime?: number
@@ -63,6 +69,10 @@ export function normalizeMaxPageLoadWaitTime({ maxPageLoadWaitTime, quietTime }:
 export class QuietPeriodAwaiter {
 	readonly promise: Promise<PageLoadMetricsResult>
 
+	private readonly getLoadingResourceUrls: () => string[]
+
+	private readonly getLoadingResourcesCount: () => number
+
 	private isResolved = false
 
 	private lastResourceTimestamp: number | undefined
@@ -78,10 +88,14 @@ export class QuietPeriodAwaiter {
 	private timeoutId: ReturnType<typeof setTimeout> | undefined
 
 	constructor({
+		getLoadingResourcesCount,
+		getLoadingResourceUrls,
 		maxPageLoadWaitTime = DEFAULT_MAX_PAGE_LOAD_WAIT_TIME,
 		quietTime = DEFAULT_QUIET_TIME,
 		startTime = performance.now(),
-	}: QuietPeriodAwaiterConfig = {}) {
+	}: QuietPeriodAwaiterConfig) {
+		this.getLoadingResourceUrls = getLoadingResourceUrls
+		this.getLoadingResourcesCount = getLoadingResourcesCount
 		this.startTime = startTime
 		this.quietTime = quietTime
 		this.maxPageLoadWaitTime = maxPageLoadWaitTime
@@ -169,7 +183,7 @@ export class QuietPeriodAwaiter {
 
 	private readonly resolve: (resolveValue: PageLoadMetricsResult) => void = () => {}
 
-	private resolveOnce(resolveValue: PageLoadMetricsResult): void {
+	private resolveOnce(resolveValue: PageLoadMetricsResolveValue): void {
 		if (this.isResolved) {
 			return
 		}
@@ -180,6 +194,24 @@ export class QuietPeriodAwaiter {
 		this.timeoutId = undefined
 		this.maxWaitTimeoutId = undefined
 		window.removeEventListener('pagehide', this.interruptListener, INTERRUPT_LISTENER_REMOVE_OPTIONS)
-		this.resolve(resolveValue)
+		this.resolve(this.withLoadingResourcesDetails(resolveValue))
+	}
+
+	private withLoadingResourcesDetails(resolveValue: PageLoadMetricsResolveValue): PageLoadMetricsResult {
+		if (resolveValue.status === PAGE_LOAD_METRICS_STATUS_COMPLETED) {
+			return {
+				...resolveValue,
+				loadingResourcesCount: 0,
+				loadingResourceUrls: [],
+			}
+		}
+
+		const loadingResourcesCount = this.getLoadingResourcesCount()
+
+		return {
+			...resolveValue,
+			loadingResourcesCount,
+			loadingResourceUrls: loadingResourcesCount > 0 ? this.getLoadingResourceUrls() : [],
+		}
 	}
 }

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -332,6 +332,8 @@ describe('SpaMetricsManager', () => {
 		const result = await promise
 		expect(result).toHaveProperty('pct')
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(result.loadingResourcesCount).toBe(0)
+		expect(result.loadingResourceUrls).toEqual([])
 
 		manager.stop()
 	})
@@ -349,6 +351,8 @@ describe('SpaMetricsManager', () => {
 		expect(result.pct).toBeGreaterThanOrEqual(documentLoadTime)
 		expect(result.pct).toBeGreaterThan(0)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(result.loadingResourcesCount).toBe(0)
+		expect(result.loadingResourceUrls).toEqual([])
 
 		manager.stop()
 	})
@@ -367,6 +371,8 @@ describe('SpaMetricsManager', () => {
 
 			expect(result.pct).toBe(3000)
 			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+			expect(result.loadingResourcesCount).toBe(1)
+			expect(result.loadingResourceUrls).toEqual([`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`])
 		} finally {
 			slowResourceAbortController.abort()
 			manager.stop()
@@ -395,6 +401,8 @@ describe('SpaMetricsManager', () => {
 
 			expect(result.pct).toBe(10)
 			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+			expect(result.loadingResourcesCount).toBe(1)
+			expect(result.loadingResourceUrls).toEqual([TEST_API_URL])
 		} finally {
 			getEntriesByType.mockRestore()
 			manager.stop()
@@ -419,6 +427,8 @@ describe('SpaMetricsManager', () => {
 
 			const result = await promise
 			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+			expect(result.loadingResourcesCount).toBe(1)
+			expect(result.loadingResourceUrls).toEqual([TEST_API_URL])
 		} finally {
 			manager.stop()
 		}
@@ -429,10 +439,50 @@ describe('SpaMetricsManager', () => {
 		manager.start()
 
 		const promise = manager.waitForPageLoad({ startTime: performance.now() })
+		// @ts-expect-error onResourceStateChange is private. We use it for testing.
+		manager.onResourceStateChange({
+			id: 'r_1',
+			monitorType: 'network',
+			state: ResourceState.DISCOVERED,
+			url: TEST_API_URL,
+		})
 		manager.stop()
 
 		const result = await promise
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		expect(result.loadingResourcesCount).toBe(1)
+		expect(result.loadingResourceUrls).toEqual([TEST_API_URL])
+	})
+
+	it('waitForPageLoad reports the last three loading resource URLs', async () => {
+		const manager = new SpaMetricsManager({ maxPageLoadWaitTime: 10, quietTime: 5 })
+		manager.start()
+		const longResourceUrl = `${TEST_API_URL}?resource=4&${'a'.repeat(120)}`
+		const truncatedLongResourceUrl = `${longResourceUrl.slice(0, 97)}...`
+
+		try {
+			for (const resourceIndex of [1, 2, 3, 4]) {
+				// @ts-expect-error onResourceStateChange is private. We use it for testing.
+				manager.onResourceStateChange({
+					id: `r_${resourceIndex}`,
+					monitorType: 'network',
+					state: ResourceState.DISCOVERED,
+					url: resourceIndex === 4 ? longResourceUrl : `${TEST_API_URL}?resource=${resourceIndex}`,
+				})
+			}
+
+			const result = await manager.waitForPageLoad({ startTime: performance.now() })
+
+			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+			expect(result.loadingResourcesCount).toBe(4)
+			expect(result.loadingResourceUrls).toEqual([
+				`${TEST_API_URL}?resource=2`,
+				`${TEST_API_URL}?resource=3`,
+				truncatedLongResourceUrl,
+			])
+		} finally {
+			manager.stop()
+		}
 	})
 
 	it('tracks loading resources and manages quiet timer', () => {
@@ -586,7 +636,9 @@ describe('SpaMetricsManager', () => {
 		// @ts-expect-error loadingResources is private. We use it for testing.
 		expect(manager.loadingResources.size).toBe(0)
 
-		await promise
+		const result = await promise
+		expect(result.loadingResourcesCount).toBe(0)
+		expect(result.loadingResourceUrls).toEqual([])
 	})
 
 	it('uses the current URL override config when handling resource events', () => {

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -22,6 +22,7 @@ import { isUrlIgnored } from '@opentelemetry/core'
 import type { SpaMetricsMonitor, SpaMetricsUrlOverride } from '../../types'
 import type { Monitor } from './monitors/monitor'
 
+import { truncateString } from '../../utils/text'
 import { PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
 import { FetchXhrMonitor, MediaMonitor, PerformanceMonitor, ResourceState, ResourceStateEvent } from './monitors'
 import { normalizeMaxPageLoadWaitTime, type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
@@ -66,6 +67,9 @@ type LoadingResource = {
 	url: string
 }
 
+const MAX_LOADING_RESOURCE_URLS_TO_REPORT = 3
+const MAX_LOADING_RESOURCE_URL_LENGTH = 100
+
 export interface SpaMetricsManagerConfig extends SpaMetricsManagerConfigValues {
 	beaconEndpoint?: string
 	urlOverrides?: SpaMetricsUrlOverride[]
@@ -80,6 +84,12 @@ export class SpaMetricsManager {
 
 	private get loadingResourcesCount(): number {
 		return this.loadingResources.size
+	}
+
+	private get loadingResourceUrls(): string[] {
+		return Array.from(this.loadingResources.values())
+			.slice(-MAX_LOADING_RESOURCE_URLS_TO_REPORT)
+			.map((resource) => truncateString(resource.url, MAX_LOADING_RESOURCE_URL_LENGTH))
 	}
 
 	private readonly monitors: Record<SpaMetricsMonitor, Monitor>
@@ -153,6 +163,8 @@ export class SpaMetricsManager {
 		this.dropLoadingResourcesIgnoredByActiveConfig(activeConfig)
 
 		const quietPeriodAwaiter = new QuietPeriodAwaiter({
+			getLoadingResourcesCount: () => this.loadingResourcesCount,
+			getLoadingResourceUrls: () => this.loadingResourceUrls,
 			maxPageLoadWaitTime: activeConfig.maxPageLoadWaitTime,
 			quietTime: activeConfig.quietTime,
 			startTime,

--- a/packages/web/src/utils/text.test.ts
+++ b/packages/web/src/utils/text.test.ts
@@ -1,0 +1,43 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { describe, expect, it } from 'vitest'
+
+import { truncateString } from './text'
+
+describe('truncateString', () => {
+	it('returns the original string when it does not exceed the max length', () => {
+		expect(truncateString('hello', 5)).toBe('hello')
+		expect(truncateString('hello', 10)).toBe('hello')
+	})
+
+	it('truncates the string and appends the default suffix', () => {
+		const result = truncateString('abcdefghijklmnopqrstuvwxyz', 10)
+
+		expect(result).toBe('abcdefg...')
+		expect(result).toHaveLength(10)
+	})
+
+	it('supports a custom suffix', () => {
+		expect(truncateString('abcdefghijklmnopqrstuvwxyz', 10, '---')).toBe('abcdefg---')
+	})
+
+	it('does not exceed the max length when the suffix is longer than the limit', () => {
+		expect(truncateString('abcdefghijklmnopqrstuvwxyz', 2)).toBe('..')
+		expect(truncateString('abcdefghijklmnopqrstuvwxyz', 0)).toBe('')
+	})
+})

--- a/packages/web/src/utils/text.ts
+++ b/packages/web/src/utils/text.ts
@@ -17,15 +17,27 @@
  */
 import { traverseDFS } from './traverse'
 
+const TRUNCATED_STRING_SUFFIX = '...'
+
 export const MAX_CLICK_TEXT_LENGTH = 50
 
-export const trimClickText = (text: string) => {
-	if (text.length > MAX_CLICK_TEXT_LENGTH) {
-		return `${text.slice(0, MAX_CLICK_TEXT_LENGTH - 3)}...`
+export function truncateString(text: string, maxLength: number, suffix = TRUNCATED_STRING_SUFFIX): string {
+	if (text.length <= maxLength) {
+		return text
 	}
 
-	return text
+	if (maxLength <= 0) {
+		return ''
+	}
+
+	if (suffix.length >= maxLength) {
+		return suffix.slice(0, maxLength)
+	}
+
+	return `${text.slice(0, maxLength - suffix.length)}${suffix}`
 }
+
+export const trimClickText = (text: string) => truncateString(text, MAX_CLICK_TEXT_LENGTH)
 
 export const getTextFromNode = (nodeToGetTextFrom: Node, shouldProcessNode: (node: Node) => boolean): string => {
 	let text = ''

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -24,6 +24,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { HTTP_TEST_SERVER_URL } from '../../../tests/servers/http-constants'
 import SplunkRum from '../src'
 import {
+	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
 	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 	PAGE_LOAD_METRICS_STATUS_COMPLETED,
@@ -322,7 +324,8 @@ describe('test init', () => {
 			})
 
 			const slowResourceAbortController = new AbortController()
-			void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+			const slowResourceUrl = `${HTTP_TEST_SERVER_URL}/some-data?delay=5000`
+			void fetch(slowResourceUrl, {
 				signal: slowResourceAbortController.signal,
 			}).catch(() => {})
 
@@ -338,6 +341,14 @@ describe('test init', () => {
 						expect(documentLoadSpan).toHaveSpanAttribute(
 							BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 							PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+						)
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
+							1,
+						)
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+							JSON.stringify([slowResourceUrl]),
 						)
 					},
 					{ timeout: 6000 },
@@ -362,7 +373,8 @@ describe('test init', () => {
 			})
 
 			const slowResourceAbortController = new AbortController()
-			void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+			const slowResourceUrl = `${HTTP_TEST_SERVER_URL}/some-data?delay=5000`
+			void fetch(slowResourceUrl, {
 				signal: slowResourceAbortController.signal,
 			}).catch(() => {})
 
@@ -376,6 +388,14 @@ describe('test init', () => {
 						expect(documentLoadSpan).toHaveSpanAttribute(
 							BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 							PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+						)
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
+							1,
+						)
+						expect(documentLoadSpan).toHaveSpanAttribute(
+							BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+							JSON.stringify([slowResourceUrl]),
 						)
 					},
 					{ timeout: 6000 },
@@ -939,10 +959,11 @@ describe('test route change spa metrics timeout', () => {
 	it('sets timeout status on routeChange span when PCT computation times out', async () => {
 		const oldUrl = location.href
 		const slowResourceAbortController = new AbortController()
+		const slowResourceUrl = `${HTTP_TEST_SERVER_URL}/some-data?delay=5000`
 
 		try {
 			history.pushState({}, 'title', '/pctTimeout#WithAHash')
-			void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
+			void fetch(slowResourceUrl, {
 				signal: slowResourceAbortController.signal,
 			}).catch(() => {})
 
@@ -954,6 +975,11 @@ describe('test route change spa metrics timeout', () => {
 					expect(span).toHaveSpanAttribute(
 						BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 						PAGE_LOAD_METRICS_STATUS_TIMEOUT,
+					)
+					expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE, 1)
+					expect(span).toHaveSpanAttribute(
+						BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+						JSON.stringify([slowResourceUrl]),
 					)
 					expect(span).toHaveSpanAttribute('prev.href', oldUrl)
 				},
@@ -967,12 +993,13 @@ describe('test route change spa metrics timeout', () => {
 	it('sets interrupted status on routeChange span when page hides during PCT computation', async () => {
 		const oldUrl = location.href
 		const slowResourceAbortController = new AbortController()
-		void fetch(`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`, {
-			signal: slowResourceAbortController.signal,
-		}).catch(() => {})
+		const slowResourceUrl = `${HTTP_TEST_SERVER_URL}/some-data?delay=5000`
 
 		try {
 			history.pushState({}, 'title', '/pctInterrupted#WithAHash')
+			void fetch(slowResourceUrl, {
+				signal: slowResourceAbortController.signal,
+			}).catch(() => {})
 			window.dispatchEvent(new Event('pagehide'))
 
 			await vi.waitFor(
@@ -983,6 +1010,11 @@ describe('test route change spa metrics timeout', () => {
 						BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 						PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
 					)
+					expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE, 1)
+					expect(span).toHaveSpanAttribute(
+						BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+						JSON.stringify([slowResourceUrl]),
+					)
 					expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE)
 					expect(span).toHaveSpanAttribute('prev.href', oldUrl)
 				},
@@ -991,6 +1023,29 @@ describe('test route change spa metrics timeout', () => {
 		} finally {
 			slowResourceAbortController.abort()
 		}
+	})
+
+	it('does not set loading resource count on interrupted routeChange span when no resources are loading', async () => {
+		const oldUrl = location.href
+
+		history.pushState({}, 'title', '/pctInterruptedNoResources#WithAHash')
+		window.dispatchEvent(new Event('pagehide'))
+
+		await vi.waitFor(
+			() => {
+				const span = capturer.spans.find((s) => s.name === 'routeChange')
+				expectDefined(span, 'Check if routeChange span is present.')
+				expect(span).toHaveSpanAttribute(
+					BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
+					PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
+				)
+				expect(span).toNotHaveSpanAttribute(BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE)
+				expect(span).toNotHaveSpanAttribute(BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE)
+				expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE)
+				expect(span).toHaveSpanAttribute('prev.href', oldUrl)
+			},
+			{ timeout: 6000 },
+		)
 	})
 })
 


### PR DESCRIPTION
# Description

- Report the number of still-loading resources on timed-out and interrupted routeChange and docLoad
- Attach up to the last three loading resource URLs, truncated to 100 characters with `...`
- Only set the new loading resource attributes when the loading resource count is greater than zero

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
