### PR TITLE
feat: add element selector monitor for PCT

### DIFF
--- a/.size-limit.cjs
+++ b/.size-limit.cjs
@@ -23,7 +23,7 @@ module.exports = [
 	},
 
 	{
-		limit: '106 kB',
+		limit: '107 kB',
 		name: 'artifacts/splunk-otel-web.js',
 		path: './packages/web/dist/artifacts/splunk-otel-web.js',
 	},

--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.ejs
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.ejs
@@ -5,12 +5,19 @@
 	<title>SPA Metrics test</title>
 	<%- renderAgent({
 		spaMetrics: {
+			loadingElementSelectors: ['.global-loading-spinner'],
 			maxPageLoadWaitTime: 1000,
+			monitors: ['media', 'network', 'performance', 'elements'],
 			quietTime: 500,
 			urlOverrides: [
 				{
 					match: '#network-disabled',
 					monitors: ['media', 'performance'],
+				},
+				{
+					loadingElementSelectors: ['[data-override-loading]'],
+					match: '#override-loading-element',
+					monitors: ['elements'],
 				},
 			],
 		},
@@ -24,10 +31,26 @@
 	<button type="button" id="btnNavigateWithImage">Navigate with image</button>
 	<button type="button" id="btnNavigateWithSlowFetch">Navigate with slow fetch</button>
 	<button type="button" id="btnNavigateWithNetworkDisabled">Navigate with network disabled</button>
+	<button type="button" id="btnNavigateWithLoadingElement">Navigate with loading element</button>
+	<button type="button" id="btnNavigateWithOverrideLoadingElement">Navigate with override loading element</button>
 
 	<div id="content"></div>
 
 	<script>
+		const LOADING_ELEMENT_RENDER_DELAY_MS = 100;
+		const LOADING_ELEMENT_VISIBLE_MS = 300;
+		window.loadingElementVisibleTimeMs = LOADING_ELEMENT_VISIBLE_MS;
+
+		function appendTemporaryLoadingElement(createSpinner) {
+			setTimeout(function () {
+				const spinner = createSpinner();
+				document.getElementById('content').appendChild(spinner);
+				setTimeout(function () {
+					spinner.remove();
+				}, LOADING_ELEMENT_VISIBLE_MS);
+			}, LOADING_ELEMENT_RENDER_DELAY_MS);
+		}
+
 		document.querySelector('#btnNavigate').addEventListener('click', function () {
 			location.hash = 'page1';
 		});
@@ -60,6 +83,28 @@
 		document.querySelector('#btnNavigateWithNetworkDisabled').addEventListener('click', function () {
 			location.hash = 'network-disabled';
 			fetch('/some-data?delay=1500&resource=override-slow-fetch').catch(function () {});
+		});
+
+		document.querySelector('#btnNavigateWithLoadingElement').addEventListener('click', function () {
+			location.hash = 'loading-element';
+			appendTemporaryLoadingElement(function () {
+				const spinner = document.createElement('div');
+				spinner.className = 'global-loading-spinner';
+				spinner.style.height = '10px';
+				spinner.style.width = '10px';
+				return spinner;
+			});
+		});
+
+		document.querySelector('#btnNavigateWithOverrideLoadingElement').addEventListener('click', function () {
+			location.hash = 'override-loading-element';
+			appendTemporaryLoadingElement(function () {
+				const spinner = document.createElement('div');
+				spinner.setAttribute('data-override-loading', '');
+				spinner.style.height = '10px';
+				spinner.style.width = '10px';
+				return spinner;
+			});
 		});
 	</script>
 </body>

--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.ejs
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.ejs
@@ -5,7 +5,7 @@
 	<title>SPA Metrics test</title>
 	<%- renderAgent({
 		spaMetrics: {
-			loadingElementSelectors: ['.global-loading-spinner'],
+			blockingSelectors: ['.global-loading-spinner'],
 			maxPageLoadWaitTime: 1000,
 			monitors: ['media', 'network', 'performance', 'elements'],
 			quietTime: 500,
@@ -15,7 +15,7 @@
 					monitors: ['media', 'performance'],
 				},
 				{
-					loadingElementSelectors: ['[data-override-loading]'],
+					blockingSelectors: ['[data-override-loading]'],
 					match: '#override-loading-element',
 					monitors: ['elements'],
 				},

--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
@@ -20,6 +20,9 @@ import { expect } from '@playwright/test'
 
 import { test } from '../../utils/test'
 
+const getPageCompletionTime = (span: { attributes: Record<string, unknown> }) =>
+	Number(span.attributes['browser.navigation.page_completion_time'])
+
 test.describe('spa-metrics', () => {
 	test('routeChange span has duration after quiet period', async ({ recordPage }) => {
 		await recordPage.goTo('/user-interaction/spa-metrics.ejs')
@@ -127,5 +130,34 @@ test.describe('spa-metrics', () => {
 		expect(overrideConfigSpan).toHaveSpanAttributeContaining('location.href', '#network-disabled')
 		expect(overrideConfigSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 0)
 		expect(overrideConfigSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
+	})
+
+	test('routeChange span waits for loading element selectors to disappear', async ({ recordPage }) => {
+		await recordPage.goTo('/user-interaction/spa-metrics.ejs')
+		const loadingElementVisibleTimeMs = await recordPage.evaluate(
+			() => (window as unknown as { loadingElementVisibleTimeMs: number }).loadingElementVisibleTimeMs,
+		)
+
+		await recordPage.locator('#btnNavigateWithLoadingElement').click()
+		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'routeChange').length === 1)
+
+		await recordPage.locator('#btnNavigateWithOverrideLoadingElement').click()
+		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'routeChange').length === 2)
+
+		const routeChangeSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
+		const globalSelectorSpan = routeChangeSpans[0]
+		const overrideSelectorSpan = routeChangeSpans[1]
+
+		expect(globalSelectorSpan).toHaveSpanAttributeContaining('location.href', '#loading-element')
+		expect(globalSelectorSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
+		expect(globalSelectorSpan).toHaveSpanDurationGreaterThan(loadingElementVisibleTimeMs * 1000)
+		expect(getPageCompletionTime(globalSelectorSpan)).toBeGreaterThan(loadingElementVisibleTimeMs)
+		expect(globalSelectorSpan).toNotHaveSpanAttribute('browser.navigation.loading_resource_count')
+
+		expect(overrideSelectorSpan).toHaveSpanAttributeContaining('location.href', '#override-loading-element')
+		expect(overrideSelectorSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
+		expect(overrideSelectorSpan).toHaveSpanDurationGreaterThan(loadingElementVisibleTimeMs * 1000)
+		expect(getPageCompletionTime(overrideSelectorSpan)).toBeGreaterThan(loadingElementVisibleTimeMs)
+		expect(overrideSelectorSpan).toNotHaveSpanAttribute('browser.navigation.loading_resource_count')
 	})
 })

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -160,7 +160,7 @@ Choose a versioning strategy based on your needs:
 | `debug`                               | `boolean`                                             | ❌       | `false`                                        | Enable internal debug logging                                                                                                                                                                                                                                                                                                                                           |
 | `cookieDomain`                        | `string`                                              | ❌       | `window.location.hostname`                     | Domain for session cookies                                                                                                                                                                                                                                                                                                                                              |
 | `ignoreUrls`                          | `Array<string\|RegExp>`                               | ❌       | `[]`                                           | URLs to exclude from tracing                                                                                                                                                                                                                                                                                                                                            |
-| `spaMetrics`                          | `boolean\|Config`                                     | ❌       | `true`                                         | SPA page completion metrics. Supports global settings and ordered `urlOverrides` for page-specific `clearLoadingResourcesOnNewPage`, `quietTime`, `ignoreUrls`, `maxPageLoadWaitTime`, `maxResourcesToWatch`, and `monitors`.                                                                                                                                           |
+| `spaMetrics`                          | `boolean\|Config`                                     | ❌       | `true`                                         | SPA page completion metrics. Supports global settings and ordered `urlOverrides` for page-specific `clearLoadingResourcesOnNewPage`, `quietTime`, `ignoreUrls`, `loadingElementSelectors`, `maxPageLoadWaitTime`, `maxResourcesToWatch`, and `monitors`.                                                                                                                |
 | `globalAttributes`                    | `Attributes`                                          | ❌       | `{}`                                           | Attributes added to every span                                                                                                                                                                                                                                                                                                                                          |
 | `persistence`                         | `'cookie'\|'localStorage'`                            | ❌       | `'cookie'`                                     | Where to store session data                                                                                                                                                                                                                                                                                                                                             |
 | `disableAutomationFrameworks`         | `boolean`                                             | ❌       | `false`                                        | Block automation frameworks                                                                                                                                                                                                                                                                                                                                             |
@@ -189,7 +189,7 @@ Choose a versioning strategy based on your needs:
 
 ### SPA Metrics
 
-The `spaMetrics` option controls page completion time (PCT) calculation for document loads and SPA route changes. When `spaMetrics` is `true`, all monitor types are enabled with the default timing settings. Use `spaMetrics.monitors` globally, or inside `spaMetrics.urlOverrides`, to control which resource sources can keep PCT waiting for a specific page.
+The `spaMetrics` option controls page completion time (PCT) calculation for document loads and SPA route changes. When `spaMetrics` is `true`, the default monitor types are enabled with the default timing settings. Use `spaMetrics.monitors` globally, or inside `spaMetrics.urlOverrides`, to control which resource sources can keep PCT waiting for a specific page.
 
 By default, `spaMetrics.clearLoadingResourcesOnNewPage` is `true`, so pending resources discovered on a previous page are ignored when PCT calculation starts for a new page. Set it to `false` to keep carrying pending resources into the next page calculation unless they are filtered by the active `monitors` or `ignoreUrls` config.
 
@@ -198,8 +198,11 @@ By default, `spaMetrics.clearLoadingResourcesOnNewPage` is `true`, so pending re
 | `network`     | `fetch` and `XMLHttpRequest` lifecycle events. Requests discovered before they settle keep PCT waiting until they finish or error.            | Keep enabled for pages whose useful content depends on API calls. Disable for polling, analytics, or background requests that should not delay PCT. |
 | `media`       | Image, audio, and video elements observed in the DOM. Pending media loads keep PCT waiting until they load or error.                          | Keep enabled when above-the-fold media is part of page readiness. Disable for lazy media, autoplay, or decorative assets that can load later.       |
 | `performance` | Resource Timing entries reported through `PerformanceObserver`, including browser-loaded resources that do not flow through fetch/XHR events. | Keep enabled to include CSS, script, and other resource timing entries. Disable when resource timing noise makes PCT too broad.                     |
+| `elements`    | Visible elements matching `loadingElementSelectors`. Matching elements keep PCT waiting until they are hidden, removed, or stop matching.     | Enable for app-controlled loading indicators that mark page readiness after async rendering work.                                                   |
 
-Array fields in URL overrides replace the inherited arrays for matched URLs. For example, `monitors: ['network']` waits only for fetch/XHR activity on that page, while `monitors: ['media', 'performance']` ignores fetch/XHR activity but still watches media and resource timing entries. If an override specifies `ignoreUrls`, include any global `spaMetrics.ignoreUrls` entries that should still apply on that page.
+The `elements` monitor is opt-in. Add `'elements'` to `spaMetrics.monitors` and configure `loadingElementSelectors` to wait for visible loading indicators. Hidden elements, elements with `display: none`, and elements with `visibility: hidden` or `collapse` do not block PCT.
+
+Array fields in URL overrides replace the inherited arrays for matched URLs. For example, `monitors: ['network']` waits only for fetch/XHR activity on that page, while `monitors: ['media', 'performance']` ignores fetch/XHR activity but still watches media and resource timing entries. If an override specifies `ignoreUrls` or `loadingElementSelectors`, include any global entries that should still apply on that page.
 
 ### Long Animation Frames
 
@@ -359,8 +362,9 @@ SplunkRum.init({
 		clearLoadingResourcesOnNewPage: true,
 		quietTime: 1000,
 		ignoreUrls: ['/analytics/track'],
+		loadingElementSelectors: ['.loading-spinner'],
 		maxResourcesToWatch: 100,
-		monitors: ['media', 'network', 'performance'],
+		monitors: ['media', 'network', 'performance', 'elements'],
 		urlOverrides: [
 			{
 				// Plain strings match by substring.
@@ -374,8 +378,9 @@ SplunkRum.init({
 				// Use RegExp, or the regex string convention, for pattern matching.
 				match: /\/checkout\/.*/,
 				maxPageLoadWaitTime: 5000,
+				loadingElementSelectors: ['[data-checkout-loading]'],
 				quietTime: 2000,
-				monitors: ['network'],
+				monitors: ['network', 'elements'],
 			},
 		],
 	},

--- a/packages/web/README.md
+++ b/packages/web/README.md
@@ -160,7 +160,7 @@ Choose a versioning strategy based on your needs:
 | `debug`                               | `boolean`                                             | ❌       | `false`                                        | Enable internal debug logging                                                                                                                                                                                                                                                                                                                                           |
 | `cookieDomain`                        | `string`                                              | ❌       | `window.location.hostname`                     | Domain for session cookies                                                                                                                                                                                                                                                                                                                                              |
 | `ignoreUrls`                          | `Array<string\|RegExp>`                               | ❌       | `[]`                                           | URLs to exclude from tracing                                                                                                                                                                                                                                                                                                                                            |
-| `spaMetrics`                          | `boolean\|Config`                                     | ❌       | `true`                                         | SPA page completion metrics. Supports global settings and ordered `urlOverrides` for page-specific `clearLoadingResourcesOnNewPage`, `quietTime`, `ignoreUrls`, `loadingElementSelectors`, `maxPageLoadWaitTime`, `maxResourcesToWatch`, and `monitors`.                                                                                                                |
+| `spaMetrics`                          | `boolean\|Config`                                     | ❌       | `true`                                         | SPA page completion metrics. Supports global settings and ordered `urlOverrides` for page-specific `clearLoadingResourcesOnNewPage`, `quietTime`, `ignoreUrls`, `blockingSelectors`, `maxPageLoadWaitTime`, `maxResourcesToWatch`, and `monitors`.                                                                                                                      |
 | `globalAttributes`                    | `Attributes`                                          | ❌       | `{}`                                           | Attributes added to every span                                                                                                                                                                                                                                                                                                                                          |
 | `persistence`                         | `'cookie'\|'localStorage'`                            | ❌       | `'cookie'`                                     | Where to store session data                                                                                                                                                                                                                                                                                                                                             |
 | `disableAutomationFrameworks`         | `boolean`                                             | ❌       | `false`                                        | Block automation frameworks                                                                                                                                                                                                                                                                                                                                             |
@@ -198,11 +198,11 @@ By default, `spaMetrics.clearLoadingResourcesOnNewPage` is `true`, so pending re
 | `network`     | `fetch` and `XMLHttpRequest` lifecycle events. Requests discovered before they settle keep PCT waiting until they finish or error.            | Keep enabled for pages whose useful content depends on API calls. Disable for polling, analytics, or background requests that should not delay PCT. |
 | `media`       | Image, audio, and video elements observed in the DOM. Pending media loads keep PCT waiting until they load or error.                          | Keep enabled when above-the-fold media is part of page readiness. Disable for lazy media, autoplay, or decorative assets that can load later.       |
 | `performance` | Resource Timing entries reported through `PerformanceObserver`, including browser-loaded resources that do not flow through fetch/XHR events. | Keep enabled to include CSS, script, and other resource timing entries. Disable when resource timing noise makes PCT too broad.                     |
-| `elements`    | Visible elements matching `loadingElementSelectors`. Matching elements keep PCT waiting until they are hidden, removed, or stop matching.     | Enable for app-controlled loading indicators that mark page readiness after async rendering work.                                                   |
+| `elements`    | Visible elements matching `blockingSelectors`. Matching elements keep PCT waiting until they are hidden, removed, or stop matching.           | Enable for app-controlled loading indicators that mark page readiness after async rendering work.                                                   |
 
-The `elements` monitor is opt-in. Add `'elements'` to `spaMetrics.monitors` and configure `loadingElementSelectors` to wait for visible loading indicators. Hidden elements, elements with `display: none`, and elements with `visibility: hidden` or `collapse` do not block PCT.
+The `elements` monitor is opt-in. Add `'elements'` to `spaMetrics.monitors` and configure `blockingSelectors` to wait for visible loading indicators. Hidden elements, elements with `display: none`, and elements with `visibility: hidden` or `collapse` do not block PCT.
 
-Array fields in URL overrides replace the inherited arrays for matched URLs. For example, `monitors: ['network']` waits only for fetch/XHR activity on that page, while `monitors: ['media', 'performance']` ignores fetch/XHR activity but still watches media and resource timing entries. If an override specifies `ignoreUrls` or `loadingElementSelectors`, include any global entries that should still apply on that page.
+Array fields in URL overrides replace the inherited arrays for matched URLs. For example, `monitors: ['network']` waits only for fetch/XHR activity on that page, while `monitors: ['media', 'performance']` ignores fetch/XHR activity but still watches media and resource timing entries. If an override specifies `ignoreUrls` or `blockingSelectors`, include any global entries that should still apply on that page.
 
 ### Long Animation Frames
 
@@ -359,12 +359,12 @@ SplunkRum.init({
 	persistence: 'cookie',
 	ignoreUrls: [/\/health-check/, '/analytics/track', 'https://third-party-ads.com'],
 	spaMetrics: {
+		blockingSelectors: ['.loading-spinner'],
 		clearLoadingResourcesOnNewPage: true,
-		quietTime: 1000,
 		ignoreUrls: ['/analytics/track'],
-		loadingElementSelectors: ['.loading-spinner'],
 		maxResourcesToWatch: 100,
 		monitors: ['media', 'network', 'performance', 'elements'],
+		quietTime: 1000,
 		urlOverrides: [
 			{
 				// Plain strings match by substring.
@@ -375,12 +375,12 @@ SplunkRum.init({
 				maxResourcesToWatch: 50,
 			},
 			{
+				blockingSelectors: ['[data-checkout-loading]'],
 				// Use RegExp, or the regex string convention, for pattern matching.
 				match: /\/checkout\/.*/,
 				maxPageLoadWaitTime: 5000,
-				loadingElementSelectors: ['[data-checkout-loading]'],
-				quietTime: 2000,
 				monitors: ['network', 'elements'],
+				quietTime: 2000,
 			},
 		],
 	},

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -203,8 +203,8 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		span.setAttribute('prev.href', oldHref)
 
 		if (this.spaMetricsManager) {
-			// Wait for all in-flight resources (XHR, fetch, media) to finish loading,
-			// then resolve after a quiet period with no new network activity.
+			// Wait for all in-flight resources monitored by SPA metrics to finish loading,
+			// then resolve after a quiet period with no new monitored activity.
 			const { loadingResourcesCount, loadingResourceUrls, pct, status } =
 				await this.spaMetricsManager.waitForPageLoad({
 					startTime: performance.now(),

--- a/packages/web/src/managers/spa-metrics-manager/monitors/loading-element-monitor.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/loading-element-monitor.test.ts
@@ -1,0 +1,282 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { diag } from '@opentelemetry/api'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { LoadingElementMonitor } from './loading-element-monitor'
+import { ResourceState, ResourceStateEvent } from './monitor'
+import { expectEventStatesWithMatchingIds } from './monitor-test-utils'
+
+const LOADING_SELECTOR = '.loading-spinner'
+const TEST_ELEMENT_CLASS = 'splunk-test-loading-element'
+
+const createVisibleLoadingElement = (): HTMLElement => {
+	const element = document.createElement('div')
+	element.className = `loading-spinner ${TEST_ELEMENT_CLASS}`
+	element.style.height = '10px'
+	element.style.width = '10px'
+	document.body.append(element)
+	return element
+}
+
+const waitForScan = () => new Promise((resolve) => setTimeout(resolve, 20))
+const getObserver = (loadingElementMonitor: LoadingElementMonitor) =>
+	(loadingElementMonitor as unknown as { observer: MutationObserver | null }).observer
+
+describe('LoadingElementMonitor', () => {
+	let events: ResourceStateEvent[]
+	let monitor: LoadingElementMonitor
+
+	beforeEach(() => {
+		events = []
+		monitor = new LoadingElementMonitor({
+			onResourceStateChange: (event) => events.push(event),
+		})
+	})
+
+	afterEach(() => {
+		monitor.stop()
+		document.body.querySelectorAll(`.${TEST_ELEMENT_CLASS}, .loading-spinner`).forEach((element) => {
+			element.remove()
+		})
+	})
+
+	it('tracks visible existing elements when refreshed', () => {
+		createVisibleLoadingElement()
+
+		monitor.refresh([LOADING_SELECTOR])
+
+		expect(events).toHaveLength(1)
+		expect(events[0].monitorType).toBe('elements')
+		expect(events[0].state).toBe(ResourceState.DISCOVERED)
+		expect(events[0].url).toBe(`element:${LOADING_SELECTOR}`)
+	})
+
+	it('keeps a visible selector tracked when refreshed without dropped resources', () => {
+		createVisibleLoadingElement()
+
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.refresh([LOADING_SELECTOR])
+
+		expect(events.map((event) => event.state)).toEqual([ResourceState.DISCOVERED])
+	})
+
+	it('discovers a new resource when a visible selector was dropped by the manager', () => {
+		createVisibleLoadingElement()
+
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.refresh([LOADING_SELECTOR], { droppedResourceUrls: [`element:${LOADING_SELECTOR}`] })
+
+		expect(events.map((event) => event.state)).toEqual([ResourceState.DISCOVERED, ResourceState.DISCOVERED])
+		expect(events[1].id).not.toBe(events[0].id)
+	})
+
+	it('tracks dynamically added visible elements', async () => {
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		createVisibleLoadingElement()
+
+		await vi.waitFor(() => {
+			expect(events.map((event) => event.state)).toEqual([ResourceState.DISCOVERED])
+		})
+	})
+
+	it('observes mutations only while monitoring with selectors', async () => {
+		monitor.start()
+		expect(getObserver(monitor)).toBeNull()
+
+		monitor.refresh([LOADING_SELECTOR])
+		expect(getObserver(monitor)).not.toBeNull()
+
+		createVisibleLoadingElement()
+
+		await vi.waitFor(() => {
+			expect(events.map((event) => event.state)).toEqual([ResourceState.DISCOVERED])
+		})
+
+		monitor.refresh([])
+		expect(getObserver(monitor)).toBeNull()
+	})
+
+	it('marks removed elements as loaded', async () => {
+		const element = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		element.remove()
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('keeps one selector resource loading until all matching elements are gone', async () => {
+		const firstElement = createVisibleLoadingElement()
+		const secondElement = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		firstElement.remove()
+		await waitForScan()
+
+		expect(events.map((event) => event.state)).toEqual([ResourceState.DISCOVERED])
+
+		secondElement.remove()
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('marks elements with display none as loaded', async () => {
+		const element = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		element.style.display = 'none'
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('discovers a new resource when a selector becomes visible again after being hidden', async () => {
+		const element = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		element.style.display = 'none'
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+
+		element.style.display = 'block'
+
+		await vi.waitFor(() => {
+			expect(events.map((event) => event.state)).toEqual([
+				ResourceState.DISCOVERED,
+				ResourceState.LOADED,
+				ResourceState.DISCOVERED,
+			])
+		})
+
+		element.style.display = 'none'
+
+		await vi.waitFor(() => {
+			expect(events.map((event) => event.state)).toEqual([
+				ResourceState.DISCOVERED,
+				ResourceState.LOADED,
+				ResourceState.DISCOVERED,
+				ResourceState.LOADED,
+			])
+		})
+
+		expect(events[0].id).toBe(events[1].id)
+		expect(events[2].id).toBe(events[3].id)
+		expect(events[0].id).not.toBe(events[2].id)
+	})
+
+	it('marks elements with visibility hidden as loaded', async () => {
+		const element = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		element.style.visibility = 'hidden'
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('marks hidden elements as loaded', async () => {
+		const element = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		element.hidden = true
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('marks elements that stop matching after class changes as loaded', async () => {
+		const element = createVisibleLoadingElement()
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+
+		element.className = TEST_ELEMENT_CLASS
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('tracks arbitrary attribute selector changes', async () => {
+		const selector = '[aria-busy="true"]'
+		const element = document.createElement('div')
+		element.className = TEST_ELEMENT_CLASS
+		element.style.height = '10px'
+		element.style.width = '10px'
+		document.body.append(element)
+		monitor.refresh([selector])
+		monitor.start()
+
+		element.setAttribute('aria-busy', 'true')
+
+		await vi.waitFor(() => {
+			expect(events.map((event) => event.state)).toEqual([ResourceState.DISCOVERED])
+		})
+
+		element.setAttribute('aria-busy', 'false')
+
+		await vi.waitFor(() => {
+			expectEventStatesWithMatchingIds(events, [ResourceState.DISCOVERED, ResourceState.LOADED])
+		})
+	})
+
+	it('warns once and skips invalid selectors', () => {
+		const warnSpy = vi.spyOn(diag, 'warn')
+		const invalidSelector = '['
+
+		monitor.refresh([invalidSelector])
+		monitor.refresh([invalidSelector])
+
+		expect(events).toHaveLength(0)
+		expect(warnSpy).toHaveBeenCalledTimes(1)
+		expect(warnSpy).toHaveBeenCalledWith(
+			'PageLoadingManager.LoadingElementMonitor: Invalid loading element selector.',
+			expect.objectContaining({ selector: invalidSelector }),
+		)
+		warnSpy.mockRestore()
+	})
+
+	it('stops observing element changes after stop', async () => {
+		monitor.refresh([LOADING_SELECTOR])
+		monitor.start()
+		monitor.stop()
+
+		createVisibleLoadingElement()
+		await waitForScan()
+
+		expect(events).toHaveLength(0)
+	})
+})

--- a/packages/web/src/managers/spa-metrics-manager/monitors/loading-element-monitor.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/loading-element-monitor.ts
@@ -1,0 +1,286 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { diag } from '@opentelemetry/api'
+
+import { isElement, type SpaMetricsMonitor } from '../../../types'
+import { Monitor } from './monitor'
+
+type MonitoredSelector = {
+	id: string
+	startTime: number
+	url: string
+}
+
+type LoadingElementMonitorRefreshOptions = {
+	droppedResourceUrls?: string[]
+}
+
+const LOADING_ELEMENT_URL_PREFIX = 'element:'
+
+/**
+ * Watches configured CSS selectors and tracks each selector, not each DOM element, as one loading resource.
+ * Multiple visible elements can match the same selector at the same time; they are collapsed into that
+ * single selector resource.
+ *
+ * Example: if one or more `.loading-spinner` elements are visible, this monitor emits one DISCOVERED
+ * resource with `url: "element:.loading-spinner"`. It emits the matching LOADED event only when no
+ * visible element matches `.loading-spinner` anymore, so removing one of several spinners does not
+ * complete the resource too early.
+ */
+export class LoadingElementMonitor extends Monitor {
+	protected readonly monitorType: SpaMetricsMonitor = 'elements'
+
+	private isMonitoring = false
+
+	private monitoredSelectors = new Map<string, MonitoredSelector>()
+
+	private observer: MutationObserver | null = null
+
+	private scanTimeoutId: ReturnType<typeof setTimeout> | undefined
+
+	private selectors: string[] = []
+
+	private warnedInvalidSelectors = new Set<string>()
+
+	/**
+	 * Applies the selectors for the currently active URL config and scans immediately.
+	 * This is called when PCT starts so elements already visible before the MutationObserver
+	 * sees any changes are still counted.
+	 */
+	refresh(selectors: string[], options: LoadingElementMonitorRefreshOptions = {}): void {
+		this.clearScheduledScan()
+		this.forgetDroppedResources(options.droppedResourceUrls)
+		this.setSelectors(selectors)
+		this.syncMutationObserver()
+		this.scanSelectors()
+	}
+
+	start(): void {
+		if (this.isMonitoring) {
+			diag.warn('PageLoadingManager.LoadingElementMonitor: Already monitoring loading elements.')
+			return
+		}
+
+		this.isMonitoring = true
+		this.syncMutationObserver()
+		this.scanSelectors()
+
+		diag.debug('PageLoadingManager.LoadingElementMonitor: Started monitoring loading elements.')
+	}
+
+	stop(): void {
+		if (!this.isMonitoring) {
+			return
+		}
+
+		this.observer?.disconnect()
+		this.observer = null
+		this.clearScheduledScan()
+		// The manager interrupts/clears pending PCT resources on stop, so there is no need
+		// to emit LOADED events for selectors that were still visible.
+		this.monitoredSelectors.clear()
+		this.isMonitoring = false
+
+		diag.debug('PageLoadingManager.LoadingElementMonitor: Stopped monitoring.')
+	}
+
+	private clearScheduledScan(): void {
+		if (this.scanTimeoutId === undefined) {
+			return
+		}
+
+		clearTimeout(this.scanTimeoutId)
+		this.scanTimeoutId = undefined
+	}
+
+	/**
+	 * Marks a selector as no longer blocking page completion.
+	 * The resource id must match the original DISCOVERED event so SpaMetricsManager can
+	 * remove the exact pending resource.
+	 */
+	private completeSelector(selector: string): void {
+		const monitoredSelector = this.monitoredSelectors.get(selector)
+		if (!monitoredSelector) {
+			return
+		}
+
+		this.monitoredSelectors.delete(selector)
+		this.emitResourceStateChange(
+			Monitor.createLoadedEvent(
+				monitoredSelector.id,
+				monitoredSelector.url,
+				performance.now() - monitoredSelector.startTime,
+			),
+		)
+	}
+
+	private forgetDroppedResources(droppedResourceUrls: string[] = []): void {
+		if (droppedResourceUrls.length === 0) {
+			return
+		}
+
+		const droppedResourceUrlSet = new Set(droppedResourceUrls)
+		for (const [selector, monitoredSelector] of this.monitoredSelectors) {
+			if (droppedResourceUrlSet.has(monitoredSelector.url)) {
+				this.monitoredSelectors.delete(selector)
+			}
+		}
+	}
+
+	/**
+	 * Selector resources are reported in timeout/interruption details. Prefixing them keeps
+	 * them distinguishable from network/media URLs while using the existing resource payload.
+	 */
+	private getLoadingElementUrl(selector: string): string {
+		return `${LOADING_ELEMENT_URL_PREFIX}${selector}`
+	}
+
+	/**
+	 * A selector blocks PCT if at least one matching element is currently visible.
+	 * Invalid selectors are ignored after a single warning so one bad selector does not
+	 * disable the whole monitor.
+	 */
+	private hasVisibleElement(selector: string): boolean {
+		let elements: NodeListOf<Element>
+		try {
+			elements = document.querySelectorAll(selector)
+		} catch (error) {
+			if (!this.warnedInvalidSelectors.has(selector)) {
+				this.warnedInvalidSelectors.add(selector)
+				diag.warn('PageLoadingManager.LoadingElementMonitor: Invalid loading element selector.', {
+					error,
+					selector,
+				})
+			}
+
+			return false
+		}
+
+		return Array.from(elements).some((element) => this.isElementVisible(element))
+	}
+
+	/**
+	 * Visibility is intentionally based on rendered layout, not only DOM presence.
+	 * Hidden elements, `display: none`, and `visibility: hidden/collapse` do not block PCT.
+	 */
+	private isElementVisible(element: Element): boolean {
+		if (!element.isConnected || element.hasAttribute('hidden') || element.getClientRects().length === 0) {
+			return false
+		}
+
+		const style = getComputedStyle(element)
+		return style.display !== 'none' && style.visibility !== 'hidden' && style.visibility !== 'collapse'
+	}
+
+	/**
+	 * Reconciles the current DOM with the tracked selector resources:
+	 * - visible selector not tracked yet -> emit DISCOVERED
+	 * - tracked selector no longer visible -> emit LOADED
+	 */
+	private scanSelectors(): void {
+		this.clearScheduledScan()
+
+		for (const selector of this.selectors) {
+			const isVisible = this.hasVisibleElement(selector)
+			const monitoredSelector = this.monitoredSelectors.get(selector)
+
+			if (isVisible && !monitoredSelector) {
+				const url = this.getLoadingElementUrl(selector)
+				const event = Monitor.createDiscoveredEvent(url)
+				this.monitoredSelectors.set(selector, {
+					id: event.id,
+					startTime: performance.now(),
+					url,
+				})
+				this.emitResourceStateChange(event)
+			} else if (!isVisible && monitoredSelector) {
+				this.completeSelector(selector)
+			}
+		}
+	}
+
+	/**
+	 * Batches MutationObserver notifications. DOM updates commonly arrive as several mutations
+	 * in the same turn, and scanning once is enough to know whether each selector is visible.
+	 */
+	private scheduleScan(): void {
+		if (this.scanTimeoutId !== undefined) {
+			return
+		}
+
+		this.scanTimeoutId = setTimeout(() => {
+			this.scanSelectors()
+		}, 0)
+	}
+
+	/**
+	 * Replaces the active selector list. Selectors removed by URL overrides must be completed
+	 * immediately so they do not keep the new page's PCT waiting.
+	 */
+	private setSelectors(selectors: string[]): void {
+		const nextSelectors = [...new Set(selectors)]
+		const nextSelectorSet = new Set(nextSelectors)
+		for (const selector of this.monitoredSelectors.keys()) {
+			if (!nextSelectorSet.has(selector)) {
+				this.completeSelector(selector)
+			}
+		}
+		this.selectors = nextSelectors
+	}
+
+	/**
+	 * Observes DOM changes that can affect selector visibility. Loading element selectors
+	 * accept arbitrary CSS selectors, so all attribute changes can be relevant.
+	 */
+	private setupMutationObserver(): void {
+		this.observer = new MutationObserver((mutations) => {
+			if (
+				mutations.some(
+					(mutation) =>
+						mutation.type === 'childList' || (mutation.type === 'attributes' && isElement(mutation.target)),
+				)
+			) {
+				this.scheduleScan()
+			}
+		})
+
+		this.observer.observe(document.documentElement, {
+			attributes: true,
+			childList: true,
+			subtree: true,
+		})
+	}
+
+	private shouldObserveMutations(): boolean {
+		return this.isMonitoring && this.selectors.length > 0
+	}
+
+	private syncMutationObserver(): void {
+		if (this.shouldObserveMutations()) {
+			if (!this.observer) {
+				this.setupMutationObserver()
+			}
+
+			return
+		}
+
+		this.observer?.disconnect()
+		this.observer = null
+	}
+}

--- a/packages/web/src/managers/spa-metrics-manager/monitors/media-monitor.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/media-monitor.test.ts
@@ -21,20 +21,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { HTTP_TEST_SERVER_URL } from '../../../../../../tests/servers/http-constants'
 import { MediaMonitor } from './media-monitor'
 import { ResourceState, ResourceStateEvent } from './monitor'
+import { expectEventStatesWithMatchingIds } from './monitor-test-utils'
 
 const DATA_IMAGE_URL = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7'
 const getFailedImageUrl = (resource: string, delay = 20) =>
 	`${HTTP_TEST_SERVER_URL}/test-image-error.png?delay=${delay}&resource=${resource}`
 const getTestImageUrl = (resource: string, delay = 20) =>
 	`${HTTP_TEST_SERVER_URL}/test-image.png?delay=${delay}&resource=${resource}`
-const expectEventStatesWithMatchingIds = (actualEvents: ResourceStateEvent[], expectedStates: ResourceState[]) => {
-	expect(actualEvents.map((event) => event.state)).toEqual(expectedStates)
-
-	const [firstEvent, ...remainingEvents] = actualEvents
-	remainingEvents.forEach((event) => {
-		expect(event.id).toBe(firstEvent.id)
-	})
-}
 const waitForImageLoad = (img: HTMLImageElement) =>
 	new Promise<void>((resolve, reject) => {
 		img.addEventListener('load', () => resolve(), { once: true })

--- a/packages/web/src/managers/spa-metrics-manager/monitors/monitor-test-utils.ts
+++ b/packages/web/src/managers/spa-metrics-manager/monitors/monitor-test-utils.ts
@@ -16,8 +16,18 @@
  *
  */
 
-export { FetchXhrMonitor } from './fetch-xhr-monitor'
-export { LoadingElementMonitor } from './loading-element-monitor'
-export { MediaMonitor } from './media-monitor'
-export { ResourceState, type ResourceStateEvent } from './monitor'
-export { PerformanceMonitor } from './performance-monitor'
+import { expect } from 'vitest'
+
+import type { ResourceState, ResourceStateEvent } from './monitor'
+
+export const expectEventStatesWithMatchingIds = (
+	actualEvents: ResourceStateEvent[],
+	expectedStates: ResourceState[],
+) => {
+	expect(actualEvents.map((event) => event.state)).toEqual(expectedStates)
+
+	const [firstEvent, ...remainingEvents] = actualEvents
+	remainingEvents.forEach((event) => {
+		expect(event.id).toBe(firstEvent.id)
+	})
+}

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -42,16 +42,16 @@ describe('SpaMetricsManager', () => {
 		expect(config.maxPageLoadWaitTime).toBe(180_000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toEqual([])
-		expect(config.loadingElementSelectors).toEqual([])
+		expect(config.blockingSelectors).toEqual([])
 		expect(config.monitors).toEqual(['media', 'network', 'performance'])
 		expect(config.clearLoadingResourcesOnNewPage).toBe(true)
 	})
 
 	it('applies custom config', () => {
 		const manager = new SpaMetricsManager({
+			blockingSelectors: ['.loading-spinner'],
 			clearLoadingResourcesOnNewPage: false,
 			ignoreUrls: [/test/],
-			loadingElementSelectors: ['.loading-spinner'],
 			maxPageLoadWaitTime: 5000,
 			monitors: ['network', 'elements'],
 			quietTime: 2000,
@@ -64,7 +64,7 @@ describe('SpaMetricsManager', () => {
 		expect(config.maxPageLoadWaitTime).toBe(5000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toHaveLength(1)
-		expect(config.loadingElementSelectors).toEqual(['.loading-spinner'])
+		expect(config.blockingSelectors).toEqual(['.loading-spinner'])
 		expect(config.monitors).toEqual(['network', 'elements'])
 		expect(config.clearLoadingResourcesOnNewPage).toBe(false)
 	})
@@ -125,13 +125,13 @@ describe('SpaMetricsManager', () => {
 
 	it('replaces inherited array fields in URL overrides', () => {
 		const manager = new SpaMetricsManager({
+			blockingSelectors: ['.global-loading'],
 			ignoreUrls: [/global/],
-			loadingElementSelectors: ['.global-loading'],
 			monitors: ['media', 'network'],
 			urlOverrides: [
 				{
+					blockingSelectors: ['.override-loading'],
 					ignoreUrls: [/override/],
-					loadingElementSelectors: ['.override-loading'],
 					match: '/checkout',
 					monitors: ['performance'],
 				},
@@ -141,13 +141,13 @@ describe('SpaMetricsManager', () => {
 		const config = manager.getConfigForUrl('https://example.test/checkout')
 
 		expect(config.ignoreUrls).toEqual([/override/])
-		expect(config.loadingElementSelectors).toEqual(['.override-loading'])
+		expect(config.blockingSelectors).toEqual(['.override-loading'])
 		expect(config.monitors).toEqual(['performance'])
 	})
 
-	it('inherits loading element selectors in URL overrides', () => {
+	it('inherits blocking selectors in URL overrides', () => {
 		const manager = new SpaMetricsManager({
-			loadingElementSelectors: ['.global-loading'],
+			blockingSelectors: ['.global-loading'],
 			urlOverrides: [
 				{
 					match: '/checkout',
@@ -157,7 +157,7 @@ describe('SpaMetricsManager', () => {
 
 		const config = manager.getConfigForUrl('https://example.test/checkout')
 
-		expect(config.loadingElementSelectors).toEqual(['.global-loading'])
+		expect(config.blockingSelectors).toEqual(['.global-loading'])
 	})
 
 	it('inherits and overrides clear loading resources config in URL overrides', () => {
@@ -411,7 +411,7 @@ describe('SpaMetricsManager', () => {
 		document.body.append(loadingElement)
 
 		const manager = new SpaMetricsManager({
-			loadingElementSelectors: ['.loading-spinner'],
+			blockingSelectors: ['.loading-spinner'],
 			maxPageLoadWaitTime: 10,
 			monitors: ['elements'],
 			quietTime: 5,
@@ -435,7 +435,7 @@ describe('SpaMetricsManager', () => {
 		document.body.append(loadingElement)
 
 		const manager = new SpaMetricsManager({
-			loadingElementSelectors: ['.loading-spinner'],
+			blockingSelectors: ['.loading-spinner'],
 			maxPageLoadWaitTime: 20,
 			monitors: ['elements'],
 			quietTime: 5,
@@ -482,8 +482,8 @@ describe('SpaMetricsManager', () => {
 		document.body.append(loadingElement)
 
 		const manager = new SpaMetricsManager({
+			blockingSelectors: ['.loading-spinner'],
 			clearLoadingResourcesOnNewPage: false,
-			loadingElementSelectors: ['.loading-spinner'],
 			maxPageLoadWaitTime: 100,
 			monitors: ['elements'],
 			quietTime: 5,
@@ -792,7 +792,7 @@ describe('SpaMetricsManager', () => {
 		document.body.append(loadingElement)
 
 		const manager = new SpaMetricsManager({
-			loadingElementSelectors: ['.loading-spinner'],
+			blockingSelectors: ['.loading-spinner'],
 			monitors: ['network'],
 			quietTime: 10,
 		})

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -42,6 +42,7 @@ describe('SpaMetricsManager', () => {
 		expect(config.maxPageLoadWaitTime).toBe(180_000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toEqual([])
+		expect(config.loadingElementSelectors).toEqual([])
 		expect(config.monitors).toEqual(['media', 'network', 'performance'])
 		expect(config.clearLoadingResourcesOnNewPage).toBe(true)
 	})
@@ -50,8 +51,9 @@ describe('SpaMetricsManager', () => {
 		const manager = new SpaMetricsManager({
 			clearLoadingResourcesOnNewPage: false,
 			ignoreUrls: [/test/],
+			loadingElementSelectors: ['.loading-spinner'],
 			maxPageLoadWaitTime: 5000,
-			monitors: ['network'],
+			monitors: ['network', 'elements'],
 			quietTime: 2000,
 		})
 
@@ -62,7 +64,8 @@ describe('SpaMetricsManager', () => {
 		expect(config.maxPageLoadWaitTime).toBe(5000)
 		expect(config.maxResourcesToWatch).toBe(100)
 		expect(config.ignoreUrls).toHaveLength(1)
-		expect(config.monitors).toEqual(['network'])
+		expect(config.loadingElementSelectors).toEqual(['.loading-spinner'])
+		expect(config.monitors).toEqual(['network', 'elements'])
 		expect(config.clearLoadingResourcesOnNewPage).toBe(false)
 	})
 
@@ -123,10 +126,12 @@ describe('SpaMetricsManager', () => {
 	it('replaces inherited array fields in URL overrides', () => {
 		const manager = new SpaMetricsManager({
 			ignoreUrls: [/global/],
+			loadingElementSelectors: ['.global-loading'],
 			monitors: ['media', 'network'],
 			urlOverrides: [
 				{
 					ignoreUrls: [/override/],
+					loadingElementSelectors: ['.override-loading'],
 					match: '/checkout',
 					monitors: ['performance'],
 				},
@@ -136,7 +141,23 @@ describe('SpaMetricsManager', () => {
 		const config = manager.getConfigForUrl('https://example.test/checkout')
 
 		expect(config.ignoreUrls).toEqual([/override/])
+		expect(config.loadingElementSelectors).toEqual(['.override-loading'])
 		expect(config.monitors).toEqual(['performance'])
+	})
+
+	it('inherits loading element selectors in URL overrides', () => {
+		const manager = new SpaMetricsManager({
+			loadingElementSelectors: ['.global-loading'],
+			urlOverrides: [
+				{
+					match: '/checkout',
+				},
+			],
+		})
+
+		const config = manager.getConfigForUrl('https://example.test/checkout')
+
+		expect(config.loadingElementSelectors).toEqual(['.global-loading'])
 	})
 
 	it('inherits and overrides clear loading resources config in URL overrides', () => {
@@ -304,6 +325,7 @@ describe('SpaMetricsManager', () => {
 
 		// @ts-expect-error monitors is private. We use it for testing.
 		const monitors = manager.monitors
+		const elementsStart = vi.spyOn(monitors.elements, 'start').mockImplementation(() => {})
 		const fetchXhrStart = vi.spyOn(monitors.network, 'start').mockImplementation(() => {})
 		const mediaStart = vi.spyOn(monitors.media, 'start').mockImplementation(() => {})
 		const performanceStart = vi.spyOn(monitors.performance, 'start').mockImplementation(() => {})
@@ -311,11 +333,13 @@ describe('SpaMetricsManager', () => {
 		try {
 			manager.start()
 
+			expect(elementsStart).toHaveBeenCalledOnce()
 			expect(fetchXhrStart).toHaveBeenCalledOnce()
 			expect(mediaStart).toHaveBeenCalledOnce()
 			expect(performanceStart).toHaveBeenCalledOnce()
 		} finally {
 			manager.stop()
+			elementsStart.mockRestore()
 			fetchXhrStart.mockRestore()
 			mediaStart.mockRestore()
 			performanceStart.mockRestore()
@@ -377,6 +401,125 @@ describe('SpaMetricsManager', () => {
 			slowResourceAbortController.abort()
 			manager.stop()
 		}
+	})
+
+	it('waitForPageLoad reports visible loading elements on timeout', async () => {
+		const loadingElement = document.createElement('div')
+		loadingElement.className = 'loading-spinner'
+		loadingElement.style.height = '10px'
+		loadingElement.style.width = '10px'
+		document.body.append(loadingElement)
+
+		const manager = new SpaMetricsManager({
+			loadingElementSelectors: ['.loading-spinner'],
+			maxPageLoadWaitTime: 10,
+			monitors: ['elements'],
+			quietTime: 5,
+		})
+
+		const result = await manager.waitForPageLoad({ startTime: performance.now() })
+
+		expect(result.pct).toBe(10)
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+		expect(result.loadingResourcesCount).toBe(1)
+		expect(result.loadingResourceUrls).toEqual(['element:.loading-spinner'])
+		loadingElement.remove()
+		manager.stop()
+	})
+
+	it('re-tracks still-visible loading elements after clearing previous page resources', async () => {
+		const loadingElement = document.createElement('div')
+		loadingElement.className = 'loading-spinner'
+		loadingElement.style.height = '10px'
+		loadingElement.style.width = '10px'
+		document.body.append(loadingElement)
+
+		const manager = new SpaMetricsManager({
+			loadingElementSelectors: ['.loading-spinner'],
+			maxPageLoadWaitTime: 20,
+			monitors: ['elements'],
+			quietTime: 5,
+		})
+		manager.start()
+
+		history.pushState({}, '', '#loading-previous-page')
+		const firstPagePromise = manager.waitForPageLoad({ startTime: performance.now() })
+
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(1)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		const firstResourceId = Array.from(manager.loadingResources.keys())[0]
+
+		history.pushState({}, '', '#loading-next-page')
+		const nextPagePromise = manager.waitForPageLoad({ startTime: performance.now() })
+		const firstPageResult = await firstPagePromise
+
+		expect(firstPageResult.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		expect(firstPageResult.loadingResourcesCount).toBe(1)
+		expect(firstPageResult.loadingResourceUrls).toEqual(['element:.loading-spinner'])
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(1)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		const nextResourceId = Array.from(manager.loadingResources.keys())[0]
+		expect(nextResourceId).not.toBe(firstResourceId)
+
+		const nextPageResult = await nextPagePromise
+
+		expect(nextPageResult.pct).toBe(20)
+		expect(nextPageResult.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+		expect(nextPageResult.loadingResourcesCount).toBe(1)
+		expect(nextPageResult.loadingResourceUrls).toEqual(['element:.loading-spinner'])
+
+		loadingElement.remove()
+		manager.stop()
+	})
+
+	it('keeps still-visible loading elements when clearing previous page resources is disabled', async () => {
+		const loadingElement = document.createElement('div')
+		loadingElement.className = 'loading-spinner'
+		loadingElement.style.height = '10px'
+		loadingElement.style.width = '10px'
+		document.body.append(loadingElement)
+
+		const manager = new SpaMetricsManager({
+			clearLoadingResourcesOnNewPage: false,
+			loadingElementSelectors: ['.loading-spinner'],
+			maxPageLoadWaitTime: 100,
+			monitors: ['elements'],
+			quietTime: 5,
+		})
+		manager.start()
+
+		history.pushState({}, '', '#loading-previous-page')
+		const firstPagePromise = manager.waitForPageLoad({ startTime: performance.now() })
+
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(1)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		const firstResourceId = Array.from(manager.loadingResources.keys())[0]
+
+		history.pushState({}, '', '#loading-next-page')
+		const nextPagePromise = manager.waitForPageLoad({ startTime: performance.now() })
+		const firstPageResult = await firstPagePromise
+
+		expect(firstPageResult.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
+		expect(firstPageResult.loadingResourcesCount).toBe(1)
+		expect(firstPageResult.loadingResourceUrls).toEqual(['element:.loading-spinner'])
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(1)
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(Array.from(manager.loadingResources.keys())[0]).toBe(firstResourceId)
+
+		loadingElement.remove()
+
+		const nextPageResult = await nextPagePromise
+
+		expect(nextPageResult.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(nextPageResult.loadingResourcesCount).toBe(0)
+		expect(nextPageResult.loadingResourceUrls).toEqual([])
+
+		loadingElement.remove()
+		manager.stop()
 	})
 
 	it('waitForPageLoad with startTime 0 does not exceed max page load wait time on timeout', async () => {
@@ -639,6 +782,30 @@ describe('SpaMetricsManager', () => {
 		const result = await promise
 		expect(result.loadingResourcesCount).toBe(0)
 		expect(result.loadingResourceUrls).toEqual([])
+	})
+
+	it('does not track visible loading elements when elements monitor is disabled', async () => {
+		const loadingElement = document.createElement('div')
+		loadingElement.className = 'loading-spinner'
+		loadingElement.style.height = '10px'
+		loadingElement.style.width = '10px'
+		document.body.append(loadingElement)
+
+		const manager = new SpaMetricsManager({
+			loadingElementSelectors: ['.loading-spinner'],
+			monitors: ['network'],
+			quietTime: 10,
+		})
+
+		const result = await manager.waitForPageLoad({ startTime: performance.now() })
+
+		expect(result.loadingResourcesCount).toBe(0)
+		expect(result.loadingResourceUrls).toEqual([])
+		// @ts-expect-error loadingResources is private. We use it for testing.
+		expect(manager.loadingResources.size).toBe(0)
+
+		loadingElement.remove()
+		manager.stop()
 	})
 
 	it('uses the current URL override config when handling resource events', () => {

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -20,16 +20,24 @@ import { diag } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
 import type { SpaMetricsMonitor, SpaMetricsUrlOverride } from '../../types'
-import type { Monitor } from './monitors/monitor'
+import type { Monitor, MonitorConfig } from './monitors/monitor'
 
 import { truncateString } from '../../utils/text'
 import { PAGE_LOAD_METRICS_STATUS_TIMEOUT } from './constants'
-import { FetchXhrMonitor, MediaMonitor, PerformanceMonitor, ResourceState, ResourceStateEvent } from './monitors'
+import {
+	FetchXhrMonitor,
+	LoadingElementMonitor,
+	MediaMonitor,
+	PerformanceMonitor,
+	ResourceState,
+	ResourceStateEvent,
+} from './monitors'
 import { normalizeMaxPageLoadWaitTime, type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 const SPA_METRICS_MANAGER_CONFIG_DEFAULTS = {
 	clearLoadingResourcesOnNewPage: true,
 	ignoreUrls: [] as (string | RegExp)[],
+	loadingElementSelectors: [] as string[],
 	maxPageLoadWaitTime: 180_000,
 	maxResourcesToWatch: 100,
 	monitors: ['media', 'network', 'performance'] as SpaMetricsMonitor[],
@@ -48,6 +56,7 @@ export function getDocumentLoadTime(navEntry: DocumentLoadTiming): number {
 type SpaMetricsManagerConfigValues = {
 	clearLoadingResourcesOnNewPage?: boolean
 	ignoreUrls?: (string | RegExp)[]
+	loadingElementSelectors?: string[]
 	maxPageLoadWaitTime?: number
 	maxResourcesToWatch?: number
 	monitors?: SpaMetricsMonitor[]
@@ -67,6 +76,10 @@ type LoadingResource = {
 	url: string
 }
 
+type DroppedLoadingResources = {
+	elementResourceUrls: string[]
+}
+
 const MAX_LOADING_RESOURCE_URLS_TO_REPORT = 3
 const MAX_LOADING_RESOURCE_URL_LENGTH = 100
 
@@ -82,17 +95,17 @@ export class SpaMetricsManager {
 
 	private loadingResources = new Map<string, LoadingResource>()
 
-	private get loadingResourcesCount(): number {
-		return this.loadingResources.size
-	}
-
 	private get loadingResourceUrls(): string[] {
 		return Array.from(this.loadingResources.values())
 			.slice(-MAX_LOADING_RESOURCE_URLS_TO_REPORT)
 			.map((resource) => truncateString(resource.url, MAX_LOADING_RESOURCE_URL_LENGTH))
 	}
 
-	private readonly monitors: Record<SpaMetricsMonitor, Monitor>
+	private get loadingResourcesCount(): number {
+		return this.loadingResources.size
+	}
+
+	private readonly monitors: ReturnType<typeof SpaMetricsManager.createMonitors>
 
 	private quietPeriodAwaiter: QuietPeriodAwaiter | undefined
 
@@ -110,11 +123,7 @@ export class SpaMetricsManager {
 			onResourceStateChange: this.onResourceStateChange,
 		}
 
-		this.monitors = {
-			media: new MediaMonitor(monitorConfig),
-			network: new FetchXhrMonitor(monitorConfig),
-			performance: new PerformanceMonitor(monitorConfig),
-		}
+		this.monitors = SpaMetricsManager.createMonitors(monitorConfig)
 	}
 
 	getConfigForUrl(url: string): ResolvedSpaMetricsManagerConfig {
@@ -158,9 +167,13 @@ export class SpaMetricsManager {
 	}
 
 	waitForPageLoad({ startTime }: { startTime: number }): Promise<PageLoadMetricsResult> {
-		this.quietPeriodAwaiter?.complete({ areResourcesStillLoading: this.loadingResourcesCount > 0 })
+		this.quietPeriodAwaiter?.interrupt()
 		const activeConfig = this.activeConfig
-		this.dropLoadingResourcesIgnoredByActiveConfig(activeConfig)
+		const droppedResources = this.dropLoadingResourcesIgnoredByActiveConfig(activeConfig)
+		this.monitors.elements.refresh(
+			activeConfig.monitors.includes('elements') ? activeConfig.loadingElementSelectors : [],
+			{ droppedResourceUrls: droppedResources.elementResourceUrls },
+		)
 
 		const quietPeriodAwaiter = new QuietPeriodAwaiter({
 			getLoadingResourcesCount: () => this.loadingResourcesCount,
@@ -195,7 +208,19 @@ export class SpaMetricsManager {
 		return quietPeriodAwaiter.promise
 	}
 
-	private dropLoadingResourcesIgnoredByActiveConfig(activeConfig: ResolvedSpaMetricsManagerConfig): void {
+	private static createMonitors(monitorConfig: MonitorConfig) {
+		return {
+			elements: new LoadingElementMonitor(monitorConfig),
+			media: new MediaMonitor(monitorConfig),
+			network: new FetchXhrMonitor(monitorConfig),
+			performance: new PerformanceMonitor(monitorConfig),
+		} as const satisfies Record<SpaMetricsMonitor, Monitor>
+	}
+
+	private dropLoadingResourcesIgnoredByActiveConfig(
+		activeConfig: ResolvedSpaMetricsManagerConfig,
+	): DroppedLoadingResources {
+		const droppedResources: DroppedLoadingResources = { elementResourceUrls: [] }
 		const pageUrl = location.href
 		for (const [resourceId, resource] of this.loadingResources) {
 			if (
@@ -204,8 +229,13 @@ export class SpaMetricsManager {
 				this.isIgnoredUrl(resource.url, activeConfig.ignoreUrls)
 			) {
 				this.loadingResources.delete(resourceId)
+				if (resource.monitorType === 'elements') {
+					droppedResources.elementResourceUrls.push(resource.url)
+				}
 			}
 		}
+
+		return droppedResources
 	}
 
 	private getBeaconEndpointIgnoreUrls(beaconEndpoint: string | undefined): (string | RegExp)[] {
@@ -294,6 +324,7 @@ export class SpaMetricsManager {
 				config.ignoreUrls ?? defaultConfig.ignoreUrls,
 				beaconEndpointIgnoreUrls,
 			),
+			loadingElementSelectors: [...(config.loadingElementSelectors ?? defaultConfig.loadingElementSelectors)],
 			maxPageLoadWaitTime: normalizeMaxPageLoadWaitTime({ maxPageLoadWaitTime, quietTime }),
 			maxResourcesToWatch: config.maxResourcesToWatch ?? defaultConfig.maxResourcesToWatch,
 			monitors: [...(config.monitors ?? defaultConfig.monitors)],

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -35,9 +35,9 @@ import {
 import { normalizeMaxPageLoadWaitTime, type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 const SPA_METRICS_MANAGER_CONFIG_DEFAULTS = {
+	blockingSelectors: [] as string[],
 	clearLoadingResourcesOnNewPage: true,
 	ignoreUrls: [] as (string | RegExp)[],
-	loadingElementSelectors: [] as string[],
 	maxPageLoadWaitTime: 180_000,
 	maxResourcesToWatch: 100,
 	monitors: ['media', 'network', 'performance'] as SpaMetricsMonitor[],
@@ -54,9 +54,9 @@ export function getDocumentLoadTime(navEntry: DocumentLoadTiming): number {
 }
 
 type SpaMetricsManagerConfigValues = {
+	blockingSelectors?: string[]
 	clearLoadingResourcesOnNewPage?: boolean
 	ignoreUrls?: (string | RegExp)[]
-	loadingElementSelectors?: string[]
 	maxPageLoadWaitTime?: number
 	maxResourcesToWatch?: number
 	monitors?: SpaMetricsMonitor[]
@@ -171,7 +171,7 @@ export class SpaMetricsManager {
 		const activeConfig = this.activeConfig
 		const droppedResources = this.dropLoadingResourcesIgnoredByActiveConfig(activeConfig)
 		this.monitors.elements.refresh(
-			activeConfig.monitors.includes('elements') ? activeConfig.loadingElementSelectors : [],
+			activeConfig.monitors.includes('elements') ? activeConfig.blockingSelectors : [],
 			{ droppedResourceUrls: droppedResources.elementResourceUrls },
 		)
 
@@ -318,13 +318,13 @@ export class SpaMetricsManager {
 		const maxPageLoadWaitTime = config.maxPageLoadWaitTime ?? defaultConfig.maxPageLoadWaitTime
 
 		return {
+			blockingSelectors: [...(config.blockingSelectors ?? defaultConfig.blockingSelectors)],
 			clearLoadingResourcesOnNewPage:
 				config.clearLoadingResourcesOnNewPage ?? defaultConfig.clearLoadingResourcesOnNewPage,
 			ignoreUrls: this.getResolvedIgnoreUrls(
 				config.ignoreUrls ?? defaultConfig.ignoreUrls,
 				beaconEndpointIgnoreUrls,
 			),
-			loadingElementSelectors: [...(config.loadingElementSelectors ?? defaultConfig.loadingElementSelectors)],
 			maxPageLoadWaitTime: normalizeMaxPageLoadWaitTime({ maxPageLoadWaitTime, quietTime }),
 			maxResourcesToWatch: config.maxResourcesToWatch ?? defaultConfig.maxResourcesToWatch,
 			monitors: [...(config.monitors ?? defaultConfig.monitors)],

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -106,12 +106,12 @@ export function isPersistenceType(value: string): value is PersistenceType {
 export type SpaMetricsMonitor = 'elements' | 'media' | 'network' | 'performance'
 
 type SpaMetricsOptionsBase = {
+	/** CSS selectors for visible elements that should keep PCT waiting when the elements monitor is enabled. */
+	blockingSelectors?: string[]
 	/** Clear resources triggered on previous pages before calculating PCT for a new page. @default true */
 	clearLoadingResourcesOnNewPage?: boolean
 	/** URLs to exclude from PCT tracking (e.g., analytics, third-party scripts) */
 	ignoreUrls?: Array<string | RegExp>
-	/** CSS selectors for visible loading elements that should keep PCT waiting when the elements monitor is enabled. */
-	loadingElementSelectors?: string[]
 	/** Maximum time in milliseconds to wait for PCT computation before marking it as timed out. @default 180000 */
 	maxPageLoadWaitTime?: number
 	/** Maximum number of concurrent resources to track. @default 100 */
@@ -294,9 +294,9 @@ export interface SplunkOtelWebConfig {
 	 *
 	 * // Enable with custom configuration
 	 * spaMetrics: {
+	 *   blockingSelectors: ['.loading-spinner'],
 	 *   clearLoadingResourcesOnNewPage: true,
 	 *   ignoreUrls: [/analytics\.example\.com/],
-	 *   loadingElementSelectors: ['.loading-spinner'],
 	 *   maxPageLoadWaitTime: 180000,
 	 *   maxResourcesToWatch: 100,
 	 *   monitors: ['media', 'network', 'performance', 'elements'],

--- a/packages/web/src/types/config.ts
+++ b/packages/web/src/types/config.ts
@@ -103,13 +103,15 @@ export function isPersistenceType(value: string): value is PersistenceType {
 	return ['cookie', 'localStorage'].includes(value)
 }
 
-export type SpaMetricsMonitor = 'media' | 'network' | 'performance'
+export type SpaMetricsMonitor = 'elements' | 'media' | 'network' | 'performance'
 
 type SpaMetricsOptionsBase = {
 	/** Clear resources triggered on previous pages before calculating PCT for a new page. @default true */
 	clearLoadingResourcesOnNewPage?: boolean
 	/** URLs to exclude from PCT tracking (e.g., analytics, third-party scripts) */
 	ignoreUrls?: Array<string | RegExp>
+	/** CSS selectors for visible loading elements that should keep PCT waiting when the elements monitor is enabled. */
+	loadingElementSelectors?: string[]
 	/** Maximum time in milliseconds to wait for PCT computation before marking it as timed out. @default 180000 */
 	maxPageLoadWaitTime?: number
 	/** Maximum number of concurrent resources to track. @default 100 */
@@ -280,8 +282,8 @@ export interface SplunkOtelWebConfig {
 	 * Enables SPA (Single Page Application) metrics.
 	 *
 	 * Currently supported metrics:
-	 * - **Page Completion Time (PCT)**: Measures the time from a route change until all network
-	 *   requests (fetch/XHR) and media elements have finished loading
+	 * - **Page Completion Time (PCT)**: Measures the time from a route change until all configured
+	 *   resource monitors are complete
 	 *
 	 * @default true (enabled)
 	 *
@@ -294,9 +296,10 @@ export interface SplunkOtelWebConfig {
 	 * spaMetrics: {
 	 *   clearLoadingResourcesOnNewPage: true,
 	 *   ignoreUrls: [/analytics\.example\.com/],
+	 *   loadingElementSelectors: ['.loading-spinner'],
 	 *   maxPageLoadWaitTime: 180000,
 	 *   maxResourcesToWatch: 100,
-	 *   monitors: ['media', 'network', 'performance'],
+	 *   monitors: ['media', 'network', 'performance', 'elements'],
 	 *   quietTime: 1000
 	 * }
 	 *


### PR DESCRIPTION
# Description

Adds an optional elements monitor for SPA Page Completion Time (PCT). This lets customers tell agent to wait for app-specific loading indicators, such as spinners or skeletons, before marking a route change as complete.

## Example:
```js
SplunkRum.init({
	spaMetrics: {
		monitors: ['media', 'network', 'performance', 'elements'],
		blockingSelectors: ['.loading-spinner', '[data-page-loading]'],
	},
})
```

With this config, PCT (Page Completion Time) waits while any visible element matching `.loading-spinner` or `[data-page-loading]` is present. Once those elements are removed, hidden, set to `display: none`, or set to `visibility: hidden`, the normal quiet-time logic can complete the navigation timing.

URL-specific overrides are also supported:

```js
SplunkRum.init({
	spaMetrics: {
		monitors: ['media', 'network', 'performance', 'elements'],
		loadingElementSelectors: ['.global-loading-spinner'],
		urlOverrides: [
			{
				match: '/checkout',
				blockingSelectors: ['[data-checkout-loading]'],
			},
		],
	},
})
```

For `/checkout`, only `[data-checkout-loading]` is used because array fields in URL overrides replace inherited arrays.

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
