### PR TITLE
feat: add support for custom interactive elements

### DIFF
--- a/packages/integration-tests/src/tests/frustration-signals/dead-click-interactive-selectors.ejs
+++ b/packages/integration-tests/src/tests/frustration-signals/dead-click-interactive-selectors.ejs
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+	<head>
+		<meta charset="UTF-8" />
+		<title>Dead click interactive selectors</title>
+
+		<%- renderAgent({
+			instrumentations: {
+				interactions: {
+					experimental_interactiveElementSelectors: ['.custom-interactive']
+				}
+			}
+		}) %>
+	</head>
+	<body>
+		<h1>Dead click interactive selectors</h1>
+		<div id="custom-dead" class="custom-interactive">Custom interactive</div>
+
+		<script>
+			document.addEventListener('click', () => {});
+		</script>
+	</body>
+</html>

--- a/packages/integration-tests/src/tests/frustration-signals/frustration-signals.spec.ts
+++ b/packages/integration-tests/src/tests/frustration-signals/frustration-signals.spec.ts
@@ -231,6 +231,19 @@ test.describe('Frustration signals', () => {
 			expect(recordPage.receivedSpans.filter(deadClickFilter)).toHaveLength(0)
 		})
 
+		test('Dead click detects click on element matching configured interactive selector', async ({ recordPage }) => {
+			await recordPage.goTo('/frustration-signals/dead-click-interactive-selectors.ejs')
+
+			await recordPage.locator('#custom-dead').click()
+
+			await recordPage.waitForSpans((spans) => spans.some(deadClickFilter))
+
+			const deadClickSpans = recordPage.receivedSpans.filter(deadClickFilter)
+
+			expect(deadClickSpans).toHaveLength(1)
+			expect(deadClickSpans[0]).toHaveSpanAttribute('target_xpath')
+		})
+
 		test('Dead click detects click on element with role=button', async ({ recordPage }) => {
 			await recordPage.goTo('/frustration-signals/dead-click.ejs')
 

--- a/packages/web/src/upstream/user-interaction/instrumentation.ts
+++ b/packages/web/src/upstream/user-interaction/instrumentation.ts
@@ -283,8 +283,10 @@ export class UserInteractionInstrumentation<
 
 	private _isInteractiveElement(element: Element): boolean {
 		const interactiveElementSelectors = this.getConfig().experimental_interactiveElementSelectors ?? []
-		if (interactiveElementSelectors.some((selector) => element.matches(selector))) {
-			return true
+		for (const selector of interactiveElementSelectors) {
+			if (element.matches(selector)) {
+				return true
+			}
 		}
 
 		const tag = element.tagName.toUpperCase()

--- a/packages/web/src/upstream/user-interaction/instrumentation.ts
+++ b/packages/web/src/upstream/user-interaction/instrumentation.ts
@@ -282,6 +282,11 @@ export class UserInteractionInstrumentation<
 	}
 
 	private _isInteractiveElement(element: Element): boolean {
+		const interactiveElementSelectors = this.getConfig().experimental_interactiveElementSelectors ?? []
+		if (interactiveElementSelectors.some((selector) => element.matches(selector))) {
+			return true
+		}
+
 		const tag = element.tagName.toUpperCase()
 
 		if (tag === 'BUTTON') {

--- a/packages/web/src/upstream/user-interaction/types.ts
+++ b/packages/web/src/upstream/user-interaction/types.ts
@@ -31,6 +31,11 @@ export interface UserInteractionInstrumentationConfig extends InstrumentationCon
 	eventNames?: EventName[]
 
 	/**
+	 * CSS selectors that should be treated as interactive elements.
+	 */
+	experimental_interactiveElementSelectors?: string[]
+
+	/**
 	 * Callback function called each time new span is being created.
 	 * Return `true` to prevent span recording.
 	 * You can also use this handler to enhance created span with extra attributes.

--- a/packages/web/tests/init.test.ts
+++ b/packages/web/tests/init.test.ts
@@ -1276,6 +1276,31 @@ describe('can produce click events', () => {
 		expect(capturer.spans[0].name).toBe('dblclick')
 		expect(capturer.spans[0].attributes.component).toBe('user-interaction')
 	})
+
+	it('marks elements matching configured interactive selectors as interactive', () => {
+		deinit()
+		initWithDefaultConfig(capturer, {
+			instrumentations: {
+				interactions: {
+					experimental_interactiveElementSelectors: ['.custom-interactive'],
+				},
+			},
+		})
+
+		const element = document.createElement('div')
+		element.className = 'custom-interactive'
+		document.body.append(element)
+
+		element.addEventListener('click', function () {
+			/* nop */
+		})
+		element.dispatchEvent(new Event('click'))
+
+		expect(capturer.spans.length).toBe(1)
+		expect(capturer.spans[0]).toHaveSpanAttribute('target_interactive', true)
+
+		element.remove()
+	})
 })
 
 describe('external session handling', () => {


### PR DESCRIPTION
# Description

Add ability to specify custom selector for interactive elements.

```
instrumentations: {
	interactions: {
		experimental_interactiveElementSelectors: ['.custom-interactive']
	}
}
```

## Type of change

Delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How has this been tested?

Delete options that are not relevant.

- Added integration tests
