### PR TITLE
feat: add PCT resource diagnostics

### DIFF
--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -18,6 +18,7 @@
 import { hrTimeToMilliseconds } from '@opentelemetry/core'
 import { expect } from '@playwright/test'
 
+import { BROWSER_NAVIGATION_ATTRIBUTES, expectBrowserNavigationAttributes } from '../../utils/browser-navigation'
 import { expectDefined, test } from '../../utils/test'
 import { timesMakeSense } from '../../utils/time-make-sense'
 
@@ -163,8 +164,9 @@ test.describe('docload', () => {
 
 		const docLoadSpan = recordPage.receivedSpans.find((span) => span.name === 'documentLoad')
 		expectDefined(docLoadSpan)
+		expectBrowserNavigationAttributes(docLoadSpan, { status: 'completed' })
 
-		const pct = Number(docLoadSpan.attributes['browser.navigation.page_completion_time'])
+		const pct = Number(docLoadSpan.attributes[BROWSER_NAVIGATION_ATTRIBUTES.pageCompletionTime])
 		expect(pct).toBeGreaterThan(0)
 
 		// pct uses the same loadEventEnd - fetchStart calculation as the exported documentLoad span.

--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
@@ -18,10 +18,31 @@
 import { hrTimeToMicroseconds } from '@opentelemetry/core'
 import { expect } from '@playwright/test'
 
+import { BROWSER_NAVIGATION_ATTRIBUTES, expectBrowserNavigationAttributes } from '../../utils/browser-navigation'
 import { test } from '../../utils/test'
 
 const getPageCompletionTime = (span: { attributes: Record<string, unknown> }) =>
-	Number(span.attributes['browser.navigation.page_completion_time'])
+	Number(span.attributes[BROWSER_NAVIGATION_ATTRIBUTES.pageCompletionTime])
+
+const expectLoadedResourceAttributes = (
+	span: { attributes: Record<string, unknown> },
+	expected: { monitorType: string; url: string },
+): void => {
+	const lastLoadedResources = JSON.parse(
+		String(span.attributes[BROWSER_NAVIGATION_ATTRIBUTES.lastLoadedResources]),
+	) as Array<{ duration: number; monitorType: string; url: string }>
+	const longestLoadedResource = JSON.parse(
+		String(span.attributes[BROWSER_NAVIGATION_ATTRIBUTES.longestLoadedResource]),
+	) as { duration: number; monitorType: string; url: string }
+
+	expect(lastLoadedResources).toHaveLength(1)
+	expect(lastLoadedResources[0].monitorType).toBe(expected.monitorType)
+	expect(lastLoadedResources[0].url).toBe(expected.url)
+	expect(lastLoadedResources[0].duration).toBeGreaterThanOrEqual(0)
+	expect(longestLoadedResource.monitorType).toBe(expected.monitorType)
+	expect(longestLoadedResource.url).toBe(expected.url)
+	expect(longestLoadedResource.duration).toBeGreaterThanOrEqual(0)
+}
 
 test.describe('spa-metrics', () => {
 	test('routeChange span has duration after quiet period', async ({ recordPage }) => {
@@ -35,6 +56,12 @@ test.describe('spa-metrics', () => {
 		const routeChangeSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
 		expect(routeChangeSpans).toHaveLength(1)
 		expect(routeChangeSpans[0].name).toBe('routeChange')
+		expectBrowserNavigationAttributes(routeChangeSpans[0], {
+			detectedResourceCount: 0,
+			pageCompletionTime: 0,
+			quietTimerResetCount: 0,
+			status: 'completed',
+		})
 
 		// Duration should be 0 as no resources were loaded
 		expect(routeChangeSpans[0]).toHaveSpanDuration(0)
@@ -49,8 +76,21 @@ test.describe('spa-metrics', () => {
 		await recordPage.waitForSpans((spans) => spans.filter((span) => span.name === 'routeChange').length === 1)
 
 		const routeChangeSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
+		const fetchUrl = '/some-data'
 
 		expect(routeChangeSpans).toHaveLength(1)
+		expectBrowserNavigationAttributes(routeChangeSpans[0], {
+			detectedResourceCount: 1,
+			quietTimerResetCount: 0,
+			status: 'completed',
+		})
+		expectLoadedResourceAttributes(routeChangeSpans[0], {
+			monitorType: 'network',
+			url: fetchUrl,
+		})
+		expect(
+			Number(routeChangeSpans[0].attributes[BROWSER_NAVIGATION_ATTRIBUTES.detectedResourceCount]),
+		).toBeGreaterThan(0)
 
 		// Duration should include fetch time + quiet period
 		expect(routeChangeSpans[0]).toHaveSpanDurationGreaterThan(0)
@@ -67,6 +107,10 @@ test.describe('spa-metrics', () => {
 		const routeChangeSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
 
 		expect(routeChangeSpans).toHaveLength(1)
+		expectBrowserNavigationAttributes(routeChangeSpans[0], { status: 'completed' })
+		expect(
+			Number(routeChangeSpans[0].attributes[BROWSER_NAVIGATION_ATTRIBUTES.detectedResourceCount]),
+		).toBeGreaterThan(0)
 
 		// Duration should include image load time + quiet period
 		expect(routeChangeSpans[0]).toHaveSpanDurationGreaterThan(0)
@@ -95,6 +139,14 @@ test.describe('spa-metrics', () => {
 		expect(routeChangeSpans[0]).toHaveSpanDuration(0)
 		expect(routeChangeSpans[1]).toHaveSpanDurationGreaterThanOrEqual(0)
 		expect(routeChangeSpans[2]).toHaveSpanDurationGreaterThanOrEqual(0)
+		expectBrowserNavigationAttributes(routeChangeSpans[0], {
+			detectedResourceCount: 0,
+			pageCompletionTime: 0,
+			quietTimerResetCount: 0,
+			status: 'completed',
+		})
+		expectBrowserNavigationAttributes(routeChangeSpans[1], { status: 'completed' })
+		expectBrowserNavigationAttributes(routeChangeSpans[2], { status: 'completed' })
 		expect(
 			hrTimeToMicroseconds(routeChangeSpans[1].duration) !== hrTimeToMicroseconds(routeChangeSpans[2].duration),
 		).toBeTruthy()
@@ -118,19 +170,30 @@ test.describe('spa-metrics', () => {
 		const routeChangeSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
 		const globalConfigSpan = routeChangeSpans[0]
 		const overrideConfigSpan = routeChangeSpans[1]
+		const globalSlowFetchUrl = '/some-data?delay=1500&resource=global-slow-fetch'
 
 		expect(globalConfigSpan).toHaveSpanAttributeContaining('location.href', '#slow-fetch')
-		expect(globalConfigSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 1000)
-		expect(globalConfigSpan).toHaveSpanAttribute('browser.navigation.loading_resource_count', 1)
+		expectBrowserNavigationAttributes(globalConfigSpan, {
+			pageCompletionTime: 1000,
+			quietTimerResetCount: 0,
+			status: 'timeout',
+		})
+		expect(
+			Number(globalConfigSpan.attributes[BROWSER_NAVIGATION_ATTRIBUTES.detectedResourceCount]),
+		).toBeGreaterThanOrEqual(1)
+		expect(globalConfigSpan).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.loadingResourceCount, 1)
 		expect(globalConfigSpan).toHaveSpanAttribute(
-			'browser.navigation.loading_resource_urls',
-			JSON.stringify(['/some-data?delay=1500&resource=global-slow-fetch']),
+			BROWSER_NAVIGATION_ATTRIBUTES.loadingResourceUrls,
+			JSON.stringify([globalSlowFetchUrl]),
 		)
-		expect(globalConfigSpan).toHaveSpanAttribute('browser.navigation.status', 'timeout')
 
 		expect(overrideConfigSpan).toHaveSpanAttributeContaining('location.href', '#network-disabled')
-		expect(overrideConfigSpan).toHaveSpanAttribute('browser.navigation.page_completion_time', 0)
-		expect(overrideConfigSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
+		expectBrowserNavigationAttributes(overrideConfigSpan, {
+			detectedResourceCount: 0,
+			pageCompletionTime: 0,
+			quietTimerResetCount: 0,
+			status: 'completed',
+		})
 	})
 
 	test('routeChange span waits for loading element selectors to disappear', async ({ recordPage }) => {
@@ -150,15 +213,31 @@ test.describe('spa-metrics', () => {
 		const overrideSelectorSpan = routeChangeSpans[1]
 
 		expect(globalSelectorSpan).toHaveSpanAttributeContaining('location.href', '#loading-element')
-		expect(globalSelectorSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
+		expectBrowserNavigationAttributes(globalSelectorSpan, {
+			detectedResourceCount: 1,
+			quietTimerResetCount: 1,
+			status: 'completed',
+		})
+		expectLoadedResourceAttributes(globalSelectorSpan, {
+			monitorType: 'elements',
+			url: 'element:.global-loading-spinner',
+		})
 		expect(globalSelectorSpan).toHaveSpanDurationGreaterThan(loadingElementVisibleTimeMs * 1000)
 		expect(getPageCompletionTime(globalSelectorSpan)).toBeGreaterThan(loadingElementVisibleTimeMs)
-		expect(globalSelectorSpan).toNotHaveSpanAttribute('browser.navigation.loading_resource_count')
+		expect(globalSelectorSpan).toNotHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.loadingResourceCount)
 
 		expect(overrideSelectorSpan).toHaveSpanAttributeContaining('location.href', '#override-loading-element')
-		expect(overrideSelectorSpan).toHaveSpanAttribute('browser.navigation.status', 'completed')
+		expectBrowserNavigationAttributes(overrideSelectorSpan, {
+			detectedResourceCount: 1,
+			quietTimerResetCount: 1,
+			status: 'completed',
+		})
+		expectLoadedResourceAttributes(overrideSelectorSpan, {
+			monitorType: 'elements',
+			url: 'element:[data-override-loading]',
+		})
 		expect(overrideSelectorSpan).toHaveSpanDurationGreaterThan(loadingElementVisibleTimeMs * 1000)
 		expect(getPageCompletionTime(overrideSelectorSpan)).toBeGreaterThan(loadingElementVisibleTimeMs)
-		expect(overrideSelectorSpan).toNotHaveSpanAttribute('browser.navigation.loading_resource_count')
+		expect(overrideSelectorSpan).toNotHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.loadingResourceCount)
 	})
 })

--- a/packages/integration-tests/src/utils/browser-navigation.ts
+++ b/packages/integration-tests/src/utils/browser-navigation.ts
@@ -1,0 +1,63 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { expect } from '@playwright/test'
+import type { ExportedTestSpan } from '@test-utils/test-span.js'
+
+export const BROWSER_NAVIGATION_ATTRIBUTES = {
+	detectedResourceCount: 'browser.navigation.detected_resource_count',
+	lastLoadedResources: 'browser.navigation.last_loaded_resources',
+	loadingResourceCount: 'browser.navigation.loading_resource_count',
+	loadingResourceUrls: 'browser.navigation.loading_resource_urls',
+	longestLoadedResource: 'browser.navigation.longest_loaded_resource',
+	pageCompletionTime: 'browser.navigation.page_completion_time',
+	quietTimerResetCount: 'browser.navigation.quiet_timer_reset_count',
+	status: 'browser.navigation.status',
+} as const
+
+type BrowserNavigationAttributeExpectations = {
+	detectedResourceCount?: number
+	pageCompletionTime?: number
+	quietTimerResetCount?: number
+	status?: 'completed' | 'interrupted' | 'timeout'
+}
+
+export function expectBrowserNavigationAttributes(
+	span: ExportedTestSpan,
+	{ detectedResourceCount, pageCompletionTime, quietTimerResetCount, status }: BrowserNavigationAttributeExpectations,
+): void {
+	expect(span).toHaveNumericAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pageCompletionTime)
+	expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.status)
+	expect(span).toHaveNumericAttribute(BROWSER_NAVIGATION_ATTRIBUTES.detectedResourceCount)
+	expect(span).toHaveNumericAttribute(BROWSER_NAVIGATION_ATTRIBUTES.quietTimerResetCount)
+
+	if (status !== undefined) {
+		expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.status, status)
+	}
+
+	if (pageCompletionTime !== undefined) {
+		expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pageCompletionTime, pageCompletionTime)
+	}
+
+	if (detectedResourceCount !== undefined) {
+		expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.detectedResourceCount, detectedResourceCount)
+	}
+
+	if (quietTimerResetCount !== undefined) {
+		expect(span).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.quietTimerResetCount, quietTimerResetCount)
+	}
+}

--- a/packages/web/src/managers/spa-metrics-manager/constants.ts
+++ b/packages/web/src/managers/spa-metrics-manager/constants.ts
@@ -16,9 +16,13 @@
  *
  */
 
+export const BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE = 'browser.navigation.detected_resource_count'
+export const BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE = 'browser.navigation.last_loaded_resources'
 export const BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE = 'browser.navigation.loading_resource_count'
 export const BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE = 'browser.navigation.loading_resource_urls'
+export const BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE = 'browser.navigation.longest_loaded_resource'
 export const BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE = 'browser.navigation.page_completion_time'
+export const BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE = 'browser.navigation.quiet_timer_reset_count'
 export const BROWSER_NAVIGATION_STATUS_ATTRIBUTE = 'browser.navigation.status'
 
 export const PAGE_LOAD_METRICS_STATUS_COMPLETED = 'completed'

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.test.ts
@@ -22,17 +22,30 @@ import {
 	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
 	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
 } from './constants'
-import { type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
+import { type LoadedResourceDetails, type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
 
 type QuietPeriodAwaiterTestConfig = Omit<
 	ConstructorParameters<typeof QuietPeriodAwaiter>[0],
-	'getLoadingResourceUrls' | 'getLoadingResourcesCount'
+	| 'getDetectedResourcesCount'
+	| 'getLastLoadedResources'
+	| 'getLoadingResourceUrls'
+	| 'getLoadingResourcesCount'
+	| 'getLongestLoadedResource'
 >
+
+const noLoadedResources: LoadedResourceDetails[] = []
+
+function getNoLongestLoadedResource(): LoadedResourceDetails | undefined {
+	return noLoadedResources[0]
+}
 
 function createQuietPeriodAwaiter(config: QuietPeriodAwaiterTestConfig = {}): QuietPeriodAwaiter {
 	return new QuietPeriodAwaiter({
+		getDetectedResourcesCount: () => 0,
+		getLastLoadedResources: () => [],
 		getLoadingResourcesCount: () => 0,
 		getLoadingResourceUrls: () => [],
+		getLongestLoadedResource: getNoLongestLoadedResource,
 		maxPageLoadWaitTime: config.maxPageLoadWaitTime,
 		quietTime: config.quietTime,
 		startTime: config.startTime,
@@ -40,8 +53,10 @@ function createQuietPeriodAwaiter(config: QuietPeriodAwaiterTestConfig = {}): Qu
 }
 
 function expectNoLoadingResources(result: PageLoadMetricsResult): void {
+	expect(result.lastLoadedResources).toEqual([])
 	expect(result.loadingResourcesCount).toBe(0)
 	expect(result.loadingResourceUrls).toEqual([])
+	expect(result.longestLoadedResource).toBeUndefined()
 }
 
 describe('QuietPeriodAwaiter', () => {
@@ -72,7 +87,36 @@ describe('QuietPeriodAwaiter', () => {
 		expect(result.pct).toBeGreaterThanOrEqual(250)
 		expect(result.pct).toBeLessThan(300)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(result.quietTimerResetCount).toBe(1)
 		expectNoLoadingResources(result)
+	})
+
+	it('keeps loaded resource details when quiet period completes', async () => {
+		const loadedResource = {
+			duration: 12,
+			monitorType: 'network' as const,
+			url: 'https://example.test/loaded-resource.js',
+		}
+		const awaiter = new QuietPeriodAwaiter({
+			getDetectedResourcesCount: () => 1,
+			getLastLoadedResources: () => [loadedResource],
+			getLoadingResourcesCount: () => 0,
+			getLoadingResourceUrls: () => ['https://example.test/resource.js'],
+			getLongestLoadedResource: () => loadedResource,
+			quietTime: 10,
+			startTime: 1000,
+		})
+
+		awaiter.startQuietTimer({ resourceLoadedTimestamp: 1025 })
+		const result = await awaiter.promise
+
+		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(result.detectedResourcesCount).toBe(1)
+		expect(result.lastLoadedResources).toEqual([loadedResource])
+		expect(result.loadingResourcesCount).toBe(0)
+		expect(result.loadingResourceUrls).toEqual([])
+		expect(result.longestLoadedResource).toEqual(loadedResource)
+		expect(result.quietTimerResetCount).toBe(0)
 	})
 
 	it('keeps the latest resource timestamp when quiet timers are started out of order', async () => {
@@ -85,6 +129,7 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 		expect(result.pct).toBe(500)
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(result.quietTimerResetCount).toBe(1)
 		expectNoLoadingResources(result)
 	})
 
@@ -107,21 +152,6 @@ describe('QuietPeriodAwaiter', () => {
 		const result = await awaiter.promise
 
 		expect(result.pct).toBeGreaterThanOrEqual(0)
-		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
-		expectNoLoadingResources(result)
-	})
-
-	it('uses empty loading resource URLs when loading resource count is zero', async () => {
-		const awaiter = new QuietPeriodAwaiter({
-			getLoadingResourcesCount: () => 0,
-			getLoadingResourceUrls: () => ['https://example.test/resource.js'],
-			maxPageLoadWaitTime: 5000,
-			quietTime: 1000,
-		})
-
-		awaiter.interrupt()
-		const result = await awaiter.promise
-
 		expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_INTERRUPTED)
 		expectNoLoadingResources(result)
 	})

--- a/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
+++ b/packages/web/src/managers/spa-metrics-manager/quiet-period-awaiter.ts
@@ -18,6 +18,8 @@
 
 import { diag } from '@opentelemetry/api'
 
+import type { SpaMetricsMonitor } from '../../types'
+
 import {
 	PAGE_LOAD_METRICS_STATUS_COMPLETED,
 	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
@@ -34,18 +36,39 @@ export type PageLoadMetricsStatus =
 	| typeof PAGE_LOAD_METRICS_STATUS_INTERRUPTED
 	| typeof PAGE_LOAD_METRICS_STATUS_TIMEOUT
 
+export type LoadedResourceDetails = {
+	duration: number
+	monitorType: SpaMetricsMonitor
+	url: string
+}
+
 export type PageLoadMetricsResult = {
+	detectedResourcesCount: number
+	lastLoadedResources: LoadedResourceDetails[]
 	loadingResourceUrls: string[]
 	loadingResourcesCount: number
+	longestLoadedResource: LoadedResourceDetails | undefined
 	pct: number
+	quietTimerResetCount: number
 	status: PageLoadMetricsStatus
 }
 
-type PageLoadMetricsResolveValue = Omit<PageLoadMetricsResult, 'loadingResourcesCount' | 'loadingResourceUrls'>
+type PageLoadMetricsResolveValue = Omit<
+	PageLoadMetricsResult,
+	| 'detectedResourcesCount'
+	| 'lastLoadedResources'
+	| 'loadingResourcesCount'
+	| 'loadingResourceUrls'
+	| 'longestLoadedResource'
+	| 'quietTimerResetCount'
+>
 
 type QuietPeriodAwaiterConfig = {
+	getDetectedResourcesCount: () => number
+	getLastLoadedResources: () => LoadedResourceDetails[]
 	getLoadingResourceUrls: () => string[]
 	getLoadingResourcesCount: () => number
+	getLongestLoadedResource: () => LoadedResourceDetails | undefined
 	maxPageLoadWaitTime?: number
 	quietTime?: number
 	startTime?: number
@@ -69,9 +92,15 @@ export function normalizeMaxPageLoadWaitTime({ maxPageLoadWaitTime, quietTime }:
 export class QuietPeriodAwaiter {
 	readonly promise: Promise<PageLoadMetricsResult>
 
+	private readonly getDetectedResourcesCount: () => number
+
+	private readonly getLastLoadedResources: () => LoadedResourceDetails[]
+
 	private readonly getLoadingResourceUrls: () => string[]
 
 	private readonly getLoadingResourcesCount: () => number
+
+	private readonly getLongestLoadedResource: () => LoadedResourceDetails | undefined
 
 	private isResolved = false
 
@@ -81,19 +110,27 @@ export class QuietPeriodAwaiter {
 
 	private quietTime: number
 
+	private quietTimerResetCount = 0
+
 	private startTime: number
 
 	private timeoutId: ReturnType<typeof setTimeout> | undefined
 
 	constructor({
+		getDetectedResourcesCount,
+		getLastLoadedResources,
 		getLoadingResourcesCount,
 		getLoadingResourceUrls,
+		getLongestLoadedResource,
 		// maxPageLoadWaitTime = DEFAULT_MAX_PAGE_LOAD_WAIT_TIME,
 		quietTime = DEFAULT_QUIET_TIME,
 		startTime = performance.now(),
 	}: QuietPeriodAwaiterConfig) {
+		this.getDetectedResourcesCount = getDetectedResourcesCount
+		this.getLastLoadedResources = getLastLoadedResources
 		this.getLoadingResourceUrls = getLoadingResourceUrls
 		this.getLoadingResourcesCount = getLoadingResourcesCount
+		this.getLongestLoadedResource = getLongestLoadedResource
 		this.startTime = startTime
 		this.quietTime = quietTime
 		this.promise = new Promise<PageLoadMetricsResult>((r) => {
@@ -152,6 +189,7 @@ export class QuietPeriodAwaiter {
 
 		clearTimeout(this.timeoutId)
 		this.timeoutId = undefined
+		this.quietTimerResetCount += 1
 	}
 
 	startQuietTimer({ resourceLoadedTimestamp }: { resourceLoadedTimestamp: number }): void {
@@ -199,8 +237,12 @@ export class QuietPeriodAwaiter {
 		if (resolveValue.status === PAGE_LOAD_METRICS_STATUS_COMPLETED) {
 			return {
 				...resolveValue,
+				detectedResourcesCount: this.getDetectedResourcesCount(),
+				lastLoadedResources: this.getLastLoadedResources(),
 				loadingResourcesCount: 0,
 				loadingResourceUrls: [],
+				longestLoadedResource: this.getLongestLoadedResource(),
+				quietTimerResetCount: this.quietTimerResetCount,
 			}
 		}
 
@@ -208,8 +250,12 @@ export class QuietPeriodAwaiter {
 
 		return {
 			...resolveValue,
+			detectedResourcesCount: this.getDetectedResourcesCount(),
+			lastLoadedResources: this.getLastLoadedResources(),
 			loadingResourcesCount,
-			loadingResourceUrls: loadingResourcesCount > 0 ? this.getLoadingResourceUrls() : [],
+			loadingResourceUrls: this.getLoadingResourceUrls(),
+			longestLoadedResource: this.getLongestLoadedResource(),
+			quietTimerResetCount: this.quietTimerResetCount,
 		}
 	}
 }

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -21,9 +21,13 @@ import { describe, expect, it, vi } from 'vitest'
 
 import { HTTP_TEST_SERVER_URL } from '../../../../../tests/servers/http-constants'
 import {
+	BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+	BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE,
 	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
+	BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 	PAGE_LOAD_METRICS_STATUS_COMPLETED,
 	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
@@ -412,8 +416,10 @@ describe('SpaMetricsManager', () => {
 
 			expect(result.pct).toBe(3000)
 			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+			expect(result.detectedResourcesCount).toBeGreaterThanOrEqual(1)
 			expect(result.loadingResourcesCount).toBe(1)
 			expect(result.loadingResourceUrls).toEqual([`${HTTP_TEST_SERVER_URL}/some-data?delay=5000`])
+			expect(result.quietTimerResetCount).toBe(0)
 		} finally {
 			slowResourceAbortController.abort()
 			manager.stop()
@@ -423,20 +429,35 @@ describe('SpaMetricsManager', () => {
 	it('sets page load metric attributes on a span', () => {
 		const manager = new SpaMetricsManager()
 		const { attributes, span } = createSpanMock()
+		const lastLoadedResources = [
+			{ duration: 10, monitorType: 'network' as const, url: 'https://example.test/loaded-1' },
+			{ duration: 25, monitorType: 'performance' as const, url: 'https://example.test/loaded-2' },
+		]
+		const longestLoadedResource = lastLoadedResources[1]
 
 		manager.setPageLoadMetricAttributes(span, {
+			detectedResourcesCount: 4,
+			lastLoadedResources,
 			loadingResourcesCount: 2,
 			loadingResourceUrls: ['https://example.test/slow-1', 'https://example.test/slow-2'],
+			longestLoadedResource,
 			pct: 123,
+			quietTimerResetCount: 3,
 			status: PAGE_LOAD_METRICS_STATUS_TIMEOUT,
 		})
 
 		expect(attributes[BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE]).toBe(123)
 		expect(attributes[BROWSER_NAVIGATION_STATUS_ATTRIBUTE]).toBe(PAGE_LOAD_METRICS_STATUS_TIMEOUT)
+		expect(attributes[BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE]).toBe(4)
 		expect(attributes[BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE]).toBe(2)
 		expect(attributes[BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE]).toBe(
 			JSON.stringify(['https://example.test/slow-1', 'https://example.test/slow-2']),
 		)
+		expect(attributes[BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE]).toBe(JSON.stringify(lastLoadedResources))
+		expect(attributes[BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE]).toBe(
+			JSON.stringify(longestLoadedResource),
+		)
+		expect(attributes[BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE]).toBe(3)
 	})
 
 	it('does not set loading resource attributes when no resources are loading', () => {
@@ -444,20 +465,28 @@ describe('SpaMetricsManager', () => {
 		const { attributes, span } = createSpanMock()
 
 		manager.setPageLoadMetricAttributes(span, {
+			detectedResourcesCount: 0,
+			lastLoadedResources: [],
 			loadingResourcesCount: 0,
 			loadingResourceUrls: [],
+			longestLoadedResource: undefined,
 			pct: 10,
+			quietTimerResetCount: 0,
 			status: PAGE_LOAD_METRICS_STATUS_COMPLETED,
 		})
 
 		expect(attributes[BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE]).toBe(10)
 		expect(attributes[BROWSER_NAVIGATION_STATUS_ATTRIBUTE]).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+		expect(attributes[BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE]).toBe(0)
+		expect(attributes[BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE]).toBeUndefined()
 		expect(attributes[BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE]).toBeUndefined()
 		expect(attributes[BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE]).toBeUndefined()
+		expect(attributes[BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE]).toBeUndefined()
+		expect(attributes[BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE]).toBe(0)
 	})
 
 	it('waitForPageLoad sets page load metric attributes when a span is provided', async () => {
-		const manager = new SpaMetricsManager({ quietTime: 1 })
+		const manager = new SpaMetricsManager({ monitors: [], quietTime: 1 })
 		const { attributes, span } = createSpanMock()
 		manager.start()
 
@@ -466,8 +495,55 @@ describe('SpaMetricsManager', () => {
 
 			expect(attributes[BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE]).toBe(result.pct)
 			expect(attributes[BROWSER_NAVIGATION_STATUS_ATTRIBUTE]).toBe(result.status)
+			expect(attributes[BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE]).toBe(0)
 			expect(attributes[BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE]).toBeUndefined()
 			expect(attributes[BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE]).toBeUndefined()
+			expect(attributes[BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE]).toBe(0)
+		} finally {
+			manager.stop()
+		}
+	})
+
+	it('waitForPageLoad sets loaded resource attributes when quiet period completes', async () => {
+		const manager = new SpaMetricsManager({ quietTime: 1 })
+		const { attributes, span } = createSpanMock()
+		const loadedResource = {
+			duration: 42,
+			monitorType: 'performance' as const,
+			url: `${TEST_API_URL}?resource=completed`,
+		}
+
+		try {
+			const promise = manager.waitForPageLoad({ span, startTime: performance.now() })
+
+			// @ts-expect-error onResourceStateChange is private. We use it for testing.
+			manager.onResourceStateChange({
+				id: 'completed-resource',
+				monitorType: loadedResource.monitorType,
+				state: ResourceState.DISCOVERED,
+				url: loadedResource.url,
+			})
+			// @ts-expect-error onResourceStateChange is private. We use it for testing.
+			manager.onResourceStateChange({
+				id: 'completed-resource',
+				loadTime: loadedResource.duration,
+				monitorType: loadedResource.monitorType,
+				state: ResourceState.LOADED,
+				timestamp: performance.now(),
+				url: loadedResource.url,
+			})
+
+			const result = await promise
+
+			expect(result.status).toBe(PAGE_LOAD_METRICS_STATUS_COMPLETED)
+			expect(result.lastLoadedResources).toEqual([loadedResource])
+			expect(result.longestLoadedResource).toEqual(loadedResource)
+			expect(attributes[BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE]).toBe(
+				JSON.stringify([loadedResource]),
+			)
+			expect(attributes[BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE]).toBe(
+				JSON.stringify(loadedResource),
+			)
 		} finally {
 			manager.stop()
 		}

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -24,9 +24,13 @@ import type { Monitor, MonitorConfig } from './monitors/monitor'
 
 import { truncateString } from '../../utils/text'
 import {
+	BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
+	BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE,
 	BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE,
+	BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 	PAGE_LOAD_METRICS_STATUS_TIMEOUT,
 } from './constants'
@@ -38,7 +42,12 @@ import {
 	ResourceState,
 	ResourceStateEvent,
 } from './monitors'
-import { normalizeMaxPageLoadWaitTime, type PageLoadMetricsResult, QuietPeriodAwaiter } from './quiet-period-awaiter'
+import {
+	type LoadedResourceDetails,
+	normalizeMaxPageLoadWaitTime,
+	type PageLoadMetricsResult,
+	QuietPeriodAwaiter,
+} from './quiet-period-awaiter'
 
 const SPA_METRICS_MANAGER_CONFIG_DEFAULTS = {
 	blockingSelectors: [] as string[],
@@ -82,6 +91,12 @@ type LoadingResource = {
 	url: string
 }
 
+type PageLoadResourceTracker = {
+	detectedResourcesCount: number
+	lastLoadedResources: LoadedResourceDetails[]
+	longestLoadedResource: LoadedResourceDetails | undefined
+}
+
 type DroppedLoadingResources = {
 	elementResourceUrls: string[]
 }
@@ -92,6 +107,7 @@ type WaitForPageLoadConfig = {
 }
 
 const MAX_LOADING_RESOURCE_URLS_TO_REPORT = 3
+const MAX_LOADED_RESOURCES_TO_REPORT = 3
 const MAX_LOADING_RESOURCE_URL_LENGTH = 100
 
 export interface SpaMetricsManagerConfig extends SpaMetricsManagerConfigValues {
@@ -106,21 +122,35 @@ export class SpaMetricsManager {
 
 	private loadingResources = new Map<string, LoadingResource>()
 
+	private readonly monitors: ReturnType<typeof SpaMetricsManager.createMonitors>
+
+	private pageLoadResourceTracker: PageLoadResourceTracker | undefined
+
+	private quietPeriodAwaiter: QuietPeriodAwaiter | undefined
+
+	private readonly urlOverrides: ResolvedSpaMetricsUrlOverride[]
+
+	private get detectedResourcesCount(): number {
+		return this.pageLoadResourceTracker?.detectedResourcesCount ?? 0
+	}
+
 	private get loadingResourceUrls(): string[] {
 		return Array.from(this.loadingResources.values())
 			.slice(-MAX_LOADING_RESOURCE_URLS_TO_REPORT)
 			.map((resource) => truncateString(resource.url, MAX_LOADING_RESOURCE_URL_LENGTH))
 	}
 
+	private get lastLoadedResources(): LoadedResourceDetails[] {
+		return this.pageLoadResourceTracker?.lastLoadedResources ?? []
+	}
+
 	private get loadingResourcesCount(): number {
 		return this.loadingResources.size
 	}
 
-	private readonly monitors: ReturnType<typeof SpaMetricsManager.createMonitors>
-
-	private quietPeriodAwaiter: QuietPeriodAwaiter | undefined
-
-	private readonly urlOverrides: ResolvedSpaMetricsUrlOverride[]
+	private get longestLoadedResource(): LoadedResourceDetails | undefined {
+		return this.pageLoadResourceTracker?.longestLoadedResource
+	}
 
 	constructor(config: SpaMetricsManagerConfig = {}) {
 		const beaconEndpointIgnoreUrls = this.getBeaconEndpointIgnoreUrls(config.beaconEndpoint)
@@ -143,7 +173,16 @@ export class SpaMetricsManager {
 
 	setPageLoadMetricAttributes(
 		span: Span,
-		{ loadingResourcesCount, loadingResourceUrls, pct, status }: PageLoadMetricsResult,
+		{
+			detectedResourcesCount,
+			lastLoadedResources,
+			loadingResourcesCount,
+			loadingResourceUrls,
+			longestLoadedResource,
+			pct,
+			quietTimerResetCount,
+			status,
+		}: PageLoadMetricsResult,
 	): void {
 		span.setAttribute(BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE, pct)
 		span.setAttribute(BROWSER_NAVIGATION_STATUS_ATTRIBUTE, status)
@@ -156,6 +195,20 @@ export class SpaMetricsManager {
 					JSON.stringify(loadingResourceUrls),
 				)
 			}
+		}
+
+		span.setAttribute(BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE, detectedResourcesCount)
+		span.setAttribute(BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE, quietTimerResetCount)
+
+		if (lastLoadedResources.length > 0) {
+			span.setAttribute(BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE, JSON.stringify(lastLoadedResources))
+		}
+
+		if (longestLoadedResource) {
+			span.setAttribute(
+				BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE,
+				JSON.stringify(longestLoadedResource),
+			)
 		}
 	}
 
@@ -199,14 +252,23 @@ export class SpaMetricsManager {
 		this.quietPeriodAwaiter?.interrupt()
 		const activeConfig = this.activeConfig
 		const droppedResources = this.dropLoadingResourcesIgnoredByActiveConfig(activeConfig)
+		this.pageLoadResourceTracker = {
+			detectedResourcesCount: this.loadingResourcesCount,
+			lastLoadedResources: [],
+			longestLoadedResource: undefined,
+		}
+
 		this.monitors.elements.refresh(
 			activeConfig.monitors.includes('elements') ? activeConfig.blockingSelectors : [],
 			{ droppedResourceUrls: droppedResources.elementResourceUrls },
 		)
 
 		const quietPeriodAwaiter = new QuietPeriodAwaiter({
+			getDetectedResourcesCount: () => this.detectedResourcesCount,
+			getLastLoadedResources: () => this.lastLoadedResources,
 			getLoadingResourcesCount: () => this.loadingResourcesCount,
 			getLoadingResourceUrls: () => this.loadingResourceUrls,
+			getLongestLoadedResource: () => this.longestLoadedResource,
 			maxPageLoadWaitTime: activeConfig.maxPageLoadWaitTime,
 			quietTime: activeConfig.quietTime,
 			startTime,
@@ -334,15 +396,48 @@ export class SpaMetricsManager {
 				pageUrl: location.href,
 				url: event.url,
 			})
+			if (this.pageLoadResourceTracker) {
+				this.pageLoadResourceTracker.detectedResourcesCount += 1
+			}
+
 			diag.debug('Detected resource. Resetting quiet timer', event.url)
 			this.quietPeriodAwaiter?.removeQuietTimer()
 		} else {
-			if (this.loadingResources.delete(event.id)) {
+			const resource = this.loadingResources.get(event.id)
+			if (resource && this.loadingResources.delete(event.id)) {
+				if (event.state === ResourceState.LOADED) {
+					this.recordLoadedResource(resource, event.loadTime)
+				}
+
 				if (this.loadingResourcesCount === 0) {
 					diag.debug('No loading resources. Starting quiet timer.')
 					this.quietPeriodAwaiter?.startQuietTimer({ resourceLoadedTimestamp: event.timestamp })
 				}
 			}
+		}
+	}
+
+	private recordLoadedResource(resource: LoadingResource, duration: number): void {
+		if (!this.pageLoadResourceTracker) {
+			return
+		}
+
+		const loadedResource = {
+			duration,
+			monitorType: resource.monitorType,
+			url: truncateString(resource.url, MAX_LOADING_RESOURCE_URL_LENGTH),
+		}
+
+		this.pageLoadResourceTracker.lastLoadedResources = [
+			...this.pageLoadResourceTracker.lastLoadedResources,
+			loadedResource,
+		].slice(-MAX_LOADED_RESOURCES_TO_REPORT)
+
+		if (
+			this.pageLoadResourceTracker.longestLoadedResource === undefined ||
+			duration > this.pageLoadResourceTracker.longestLoadedResource.duration
+		) {
+			this.pageLoadResourceTracker.longestLoadedResource = loadedResource
 		}
 	}
 


### PR DESCRIPTION
# Description


Adds page-completion-time resource diagnostics to browser navigation spans.

This change tracks and reports additional navigation context:
- total detected resource count
- quiet timer reset count
- last loaded resources
- longest loaded resource
- existing loading resource diagnostics on timeout/interruption


## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
