### PR TITLE
chore: attach full rum version for locked CDN builds

### DIFF
--- a/packages/session-recorder/src/detect-latest.test.ts
+++ b/packages/session-recorder/src/detect-latest.test.ts
@@ -1,0 +1,90 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isRecorderLoadedViaLockedVersionTag, isRecorderLoadedViaNextTag } from './detect-latest'
+
+const COMMIT_HASH = 'a9c4edd78115772b67a6aa464655048f881d9f2b'
+const originalCurrentScriptDescriptor = Object.getOwnPropertyDescriptor(document, 'currentScript')
+
+const resetCurrentScript = () => {
+	if (originalCurrentScriptDescriptor) {
+		Object.defineProperty(document, 'currentScript', originalCurrentScriptDescriptor)
+		return
+	}
+
+	Reflect.deleteProperty(document, 'currentScript')
+}
+
+const setCurrentScriptSrc = (src: string) => {
+	const script = document.createElement('script')
+	script.src = src
+	Object.defineProperty(document, 'currentScript', {
+		configurable: true,
+		value: script,
+	})
+}
+
+afterEach(() => {
+	resetCurrentScript()
+})
+
+describe('isO11yGdiRumLockedVersionUrl', () => {
+	it.each([
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH}/splunk-otel-web.js`,
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH}/splunk-otel-web-session-recorder.js`,
+	])('detects locked version URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isRecorderLoadedViaLockedVersionTag()).toBe(true)
+	})
+
+	it.each([
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/3/splunk-otel-web-session-recorder.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/latest/splunk-otel-web-session-recorder.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/next/splunk-otel-web-session-recorder.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0/splunk-otel-web-session-recorder.js',
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH.slice(0, 39)}/splunk-otel-web-session-recorder.js`,
+	])('ignores non-locked version URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isRecorderLoadedViaLockedVersionTag()).toBe(false)
+	})
+})
+
+describe('isRecorderLoadedViaNextTag', () => {
+	it.each([
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/next/splunk-otel-web-session-recorder.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/NEXT/splunk-otel-web-session-recorder.js',
+	])('detects next URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isRecorderLoadedViaNextTag()).toBe(true)
+	})
+
+	it.each([
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/3/splunk-otel-web-session-recorder.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/latest/splunk-otel-web-session-recorder.js',
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH}/splunk-otel-web-session-recorder.js`,
+	])('ignores non-next URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isRecorderLoadedViaNextTag()).toBe(false)
+	})
+})

--- a/packages/session-recorder/src/detect-latest.ts
+++ b/packages/session-recorder/src/detect-latest.ts
@@ -17,6 +17,8 @@
  */
 import { isScriptElement } from './type-guards'
 
+const LOCKED_VERSION_TAG_REGEX = /\/o11y-gdi-rum\/v\d+\.\d+\.\d+-[0-9a-f]{40}\//i
+
 export const isRecorderLoadedViaLatestTag = () => {
 	let isLatestTagUsed = false
 	try {
@@ -30,6 +32,20 @@ export const isRecorderLoadedViaLatestTag = () => {
 	}
 
 	return isLatestTagUsed
+}
+
+export const isRecorderLoadedViaLockedVersionTag = () => {
+	let isLockedVersionTagUsed = false
+	try {
+		if (document.currentScript && isScriptElement(document.currentScript)) {
+			const src = document.currentScript.src
+			isLockedVersionTagUsed = LOCKED_VERSION_TAG_REGEX.test(src)
+		}
+	} catch {
+		// ignore
+	}
+
+	return isLockedVersionTagUsed
 }
 
 export const isRecorderLoadedViaNextTag = () => {

--- a/packages/session-recorder/src/index.ts
+++ b/packages/session-recorder/src/index.ts
@@ -22,7 +22,11 @@ import { JsonObject } from 'type-fest'
 
 import type { LogExporter } from './types'
 
-import { isRecorderLoadedViaLatestTag, isRecorderLoadedViaNextTag } from './detect-latest'
+import {
+	isRecorderLoadedViaLatestTag,
+	isRecorderLoadedViaLockedVersionTag,
+	isRecorderLoadedViaNextTag,
+} from './detect-latest'
 import { log } from './log'
 import OTLPLogExporter from './otlp-log-exporter'
 import { OTLPProtoLogExporter } from './otlp-proto-log-exporter'
@@ -81,7 +85,7 @@ let recorder: Recorder | undefined
 let sessionStateUnsubscribe: undefined | (() => void)
 let pendingSegmentsRetried = false
 const isLatestTagUsed = isRecorderLoadedViaLatestTag()
-const isNextTagUsed = isRecorderLoadedViaNextTag()
+const isFullVersionTagUsed = isRecorderLoadedViaNextTag() || isRecorderLoadedViaLockedVersionTag()
 
 const useIndexedDBPersistence = (config: SplunkRumRecorderConfig): boolean =>
 	config.persistFailedReplayData === 'indexeddb' || config.persistFailedReplayData === true
@@ -271,7 +275,7 @@ const SplunkRumRecorder = {
 			if (SplunkRum.provider) {
 				SplunkRum.provider.resource.attributes['splunk.sessionReplay'] = 'splunk'
 
-				if (isNextTagUsed && typeof __COMMIT_HASH__ === 'string' && __COMMIT_HASH__) {
+				if (isFullVersionTagUsed && typeof __COMMIT_HASH__ === 'string' && __COMMIT_HASH__) {
 					SplunkRum.provider.resource.attributes['splunk.rumVersionFullSessionRecorder'] = __COMMIT_HASH__
 				}
 			}

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -80,7 +80,11 @@ import {
 } from './types'
 import { generateId, getPluginConfig, normalizeIgnoreUrlsConfig } from './utils'
 import { getValidAttributes, SpanContext } from './utils/attributes'
-import { isAgentLoadedViaLatestTag, isAgentLoadedViaNextTag } from './utils/detect-latest'
+import {
+	isAgentLoadedViaLatestTag,
+	isAgentLoadedViaLockedVersionTag,
+	isAgentLoadedViaNextTag,
+} from './utils/detect-latest'
 import { isBot } from './utils/is-bot'
 import { parseVersion } from './utils/parse-version'
 import { createPicker, isPickerWindow } from './utils/picker'
@@ -289,7 +293,7 @@ let _spaMetricsManager: SpaMetricsManager | undefined
 let eventTarget: InternalEventTarget | undefined
 let _sessionStateUnsubscribe: undefined | (() => void)
 const isLatestTagUsed = isAgentLoadedViaLatestTag()
-const isNextTagUsed = isAgentLoadedViaNextTag()
+const isFullVersionTagUsed = isAgentLoadedViaNextTag() || isAgentLoadedViaLockedVersionTag()
 
 export const SplunkRum: SplunkOtelWebType = {
 	_internalInit: function (options: SplunkOtelWebConfig | Partial<SplunkOtelWebConfigInternal>) {
@@ -600,7 +604,7 @@ export const SplunkRum: SplunkOtelWebType = {
 				resourceAttrs[SYNTHETICS_TEST_ID_ATTRIBUTE] = syntheticsTestId
 			}
 
-			if (isNextTagUsed && typeof __COMMIT_HASH__ === 'string' && __COMMIT_HASH__) {
+			if (isFullVersionTagUsed && typeof __COMMIT_HASH__ === 'string' && __COMMIT_HASH__) {
 				resourceAttrs['splunk.rumVersionFull'] = __COMMIT_HASH__
 			}
 

--- a/packages/web/src/utils/detect-latest.test.ts
+++ b/packages/web/src/utils/detect-latest.test.ts
@@ -1,0 +1,90 @@
+/**
+ *
+ * Copyright 2020-2026 Splunk Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { isAgentLoadedViaLockedVersionTag, isAgentLoadedViaNextTag } from './detect-latest'
+
+const COMMIT_HASH = 'a9c4edd78115772b67a6aa464655048f881d9f2b'
+const originalCurrentScriptDescriptor = Object.getOwnPropertyDescriptor(document, 'currentScript')
+
+const resetCurrentScript = () => {
+	if (originalCurrentScriptDescriptor) {
+		Object.defineProperty(document, 'currentScript', originalCurrentScriptDescriptor)
+		return
+	}
+
+	Reflect.deleteProperty(document, 'currentScript')
+}
+
+const setCurrentScriptSrc = (src: string) => {
+	const script = document.createElement('script')
+	script.src = src
+	Object.defineProperty(document, 'currentScript', {
+		configurable: true,
+		value: script,
+	})
+}
+
+afterEach(() => {
+	resetCurrentScript()
+})
+
+describe('isO11yGdiRumLockedVersionUrl', () => {
+	it.each([
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH}/splunk-otel-web.js`,
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH}/splunk-otel-web-session-recorder.js`,
+	])('detects locked version URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isAgentLoadedViaLockedVersionTag()).toBe(true)
+	})
+
+	it.each([
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/3/splunk-otel-web.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/latest/splunk-otel-web.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/next/splunk-otel-web.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0/splunk-otel-web.js',
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH.slice(0, 39)}/splunk-otel-web.js`,
+	])('ignores non-locked version URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isAgentLoadedViaLockedVersionTag()).toBe(false)
+	})
+})
+
+describe('isAgentLoadedViaNextTag', () => {
+	it.each([
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/next/splunk-otel-web.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/NEXT/splunk-otel-web.js',
+	])('detects next URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isAgentLoadedViaNextTag()).toBe(true)
+	})
+
+	it.each([
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/3/splunk-otel-web.js',
+		'https://cdn.observability.splunkcloud.com/o11y-gdi-rum/latest/splunk-otel-web.js',
+		`https://cdn.observability.splunkcloud.com/o11y-gdi-rum/v3.0.0-${COMMIT_HASH}/splunk-otel-web.js`,
+	])('ignores non-next URL %s', (url) => {
+		setCurrentScriptSrc(url)
+
+		expect(isAgentLoadedViaNextTag()).toBe(false)
+	})
+})

--- a/packages/web/src/utils/detect-latest.ts
+++ b/packages/web/src/utils/detect-latest.ts
@@ -17,6 +17,8 @@
  */
 import { isScriptElement } from '../types'
 
+const LOCKED_VERSION_TAG_REGEX = /\/o11y-gdi-rum\/v\d+\.\d+\.\d+-[0-9a-f]{40}\//i
+
 export const isAgentLoadedViaLatestTag = () => {
 	let isLatestTagUsed = false
 	try {
@@ -30,6 +32,20 @@ export const isAgentLoadedViaLatestTag = () => {
 	}
 
 	return isLatestTagUsed
+}
+
+export const isAgentLoadedViaLockedVersionTag = () => {
+	let isLockedVersionTagUsed = false
+	try {
+		if (document.currentScript && isScriptElement(document.currentScript)) {
+			const src = document.currentScript.src
+			isLockedVersionTagUsed = LOCKED_VERSION_TAG_REGEX.test(src)
+		}
+	} catch {
+		// ignore
+	}
+
+	return isLockedVersionTagUsed
 }
 
 export const isAgentLoadedViaNextTag = () => {


### PR DESCRIPTION
# Description

Attach `splunk.rumVersionFull` when the browser agent or session recorder is loaded from a locked CDN version URL.

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
- Added unit tests
- Added integration tests

<!--
Checklist:

- Unit tests have been added/updated
- Integration tests if it's browser specific quirk
- Documentation has been updated
-->
