### PR TITLE
chore: enable hashAssetContent by default

### DIFF
--- a/packages/session-recorder/src/session-replay/recorder.ts
+++ b/packages/session-recorder/src/session-replay/recorder.ts
@@ -122,7 +122,7 @@ export class Recorder {
 				cacheAssets: this.config.features?.cacheAssets ?? true,
 				canvas: this.config.features?.canvas ?? false,
 				iframes: this.config.features?.iframes ?? false,
-				packAssets: this.config.features?.packAssets ?? { styles: true },
+				packAssets: this.config.features?.packAssets ?? { hashAssetContent: true, styles: true },
 				persistSegments,
 				segmentFlushThresholdKb: MAX_CHUNK_SIZE / 1024,
 				video: this.config.features?.video ?? false,


### PR DESCRIPTION
# Description

enable hashAssetContent by default

## Type of change

Delete options that are not relevant.

- Chore or internal change (changes not visible to the consumers of the package)

# How has this been tested?

Delete options that are not relevant.

- Manual testing
