### PR TITLE
feat: attribute spans to navigation operations

### DIFF
--- a/packages/integration-tests/src/tests/docload/docload.spec.ts
+++ b/packages/integration-tests/src/tests/docload/docload.spec.ts
@@ -89,6 +89,8 @@ test.describe('docload', () => {
 		expect(docLoadSpans[0].spanId.match(/[a-f0-9]+/), 'Checking sanity of spanId').toBeTruthy()
 		expect(docFetchSpans[0].traceId).toBe(docLoadSpans[0].traceId)
 		expect(docFetchSpans[0].parentSpanId).toBe(docLoadSpans[0].spanId)
+		expect(docLoadSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'documentLoad')
+		expect(docFetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'documentLoad')
 		expect(docFetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pageSpanId, docLoadSpans[0].spanId)
 		expect(docFetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pctRelevant, true)
 
@@ -96,6 +98,7 @@ test.describe('docload', () => {
 		expect(scriptFetchSpans[0].traceId).toBe(docLoadSpans[0].traceId)
 		expect(scriptFetchSpans[0].parentSpanId).toBe(docLoadSpans[0].spanId)
 		expect(scriptFetchSpans[0]).toHaveSpanAttribute('component', 'document-load')
+		expect(scriptFetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'documentLoad')
 		expect(scriptFetchSpans[0]).toHaveSpanAttribute(
 			BROWSER_NAVIGATION_ATTRIBUTES.pageSpanId,
 			docLoadSpans[0].spanId,

--- a/packages/integration-tests/src/tests/errors/errors.spec.ts
+++ b/packages/integration-tests/src/tests/errors/errors.spec.ts
@@ -18,6 +18,7 @@
 import { expect } from '@playwright/test'
 import type { ExportedTestSpan } from '@test-utils/test-span.js'
 
+import { BROWSER_NAVIGATION_ATTRIBUTES } from '../../utils/browser-navigation'
 import { test } from '../../utils/test'
 
 test.describe('errors', () => {
@@ -68,6 +69,7 @@ test.describe('errors', () => {
 		expect(errorSpans[0]).toHaveSpanAttribute('component', 'error')
 		expect(errorSpans[0]).toHaveSpanAttribute('error', true)
 		expect(errorSpans[0]).toHaveSpanAttribute('error.object', 'TypeError')
+		expect(errorSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'documentLoad')
 
 		const errorMessageMap = {
 			chromium: "Cannot set properties of null (setting 'prop1')",

--- a/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
+++ b/packages/integration-tests/src/tests/user-interaction/spa-metrics.spec.ts
@@ -56,6 +56,7 @@ test.describe('spa-metrics', () => {
 		const routeChangeSpans = recordPage.receivedSpans.filter((span) => span.name === 'routeChange')
 		expect(routeChangeSpans).toHaveLength(1)
 		expect(routeChangeSpans[0].name).toBe('routeChange')
+		expect(routeChangeSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'routeChange')
 		expectBrowserNavigationAttributes(routeChangeSpans[0], {
 			detectedResourceCount: 0,
 			pageCompletionTime: 0,
@@ -65,6 +66,29 @@ test.describe('spa-metrics', () => {
 
 		// Duration should be 0 as no resources were loaded
 		expect(routeChangeSpans[0]).toHaveSpanDuration(0)
+	})
+
+	test('errors after a route change have the routeChange operation', async ({ recordPage }) => {
+		await recordPage.goTo('/user-interaction/spa-metrics.ejs')
+		await recordPage.locator('#btnNavigate').click()
+		await recordPage.waitForSpans((spans) => spans.some((span) => span.name === 'routeChange'))
+
+		await recordPage.evaluate(() => {
+			setTimeout(() => {
+				throw new Error('route change operation test')
+			})
+		})
+		await recordPage.waitForSpans((spans) =>
+			spans.some(
+				(span) => span.name === 'onerror' && span.attributes['error.message'] === 'route change operation test',
+			),
+		)
+
+		const errorSpan = recordPage.receivedSpans.find(
+			(span) => span.name === 'onerror' && span.attributes['error.message'] === 'route change operation test',
+		)
+		expectDefined(errorSpan)
+		expect(errorSpan).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'routeChange')
 	})
 
 	test('routeChange span waits for fetch requests to complete', async ({ recordPage }) => {
@@ -85,6 +109,7 @@ test.describe('spa-metrics', () => {
 
 		expect(routeChangeSpans).toHaveLength(1)
 		expect(fetchSpans).toHaveLength(1)
+		expect(fetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'routeChange')
 		expect(fetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pageSpanId, routeChangeSpans[0].spanId)
 		expect(fetchSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pctRelevant, true)
 		expectBrowserNavigationAttributes(routeChangeSpans[0], {
@@ -122,6 +147,7 @@ test.describe('spa-metrics', () => {
 
 		expect(routeChangeSpans).toHaveLength(1)
 		expect(xhrSpans).toHaveLength(1)
+		expect(xhrSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.operation, 'routeChange')
 		expect(xhrSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pageSpanId, routeChangeSpans[0].spanId)
 		expect(xhrSpans[0]).toHaveSpanAttribute(BROWSER_NAVIGATION_ATTRIBUTES.pctRelevant, true)
 		expectBrowserNavigationAttributes(routeChangeSpans[0], {

--- a/packages/integration-tests/src/utils/browser-navigation.ts
+++ b/packages/integration-tests/src/utils/browser-navigation.ts
@@ -24,6 +24,7 @@ export const BROWSER_NAVIGATION_ATTRIBUTES = {
 	loadingResourceCount: 'browser.navigation.loading_resource_count',
 	loadingResourceUrls: 'browser.navigation.loading_resource_urls',
 	longestLoadedResource: 'browser.navigation.longest_loaded_resource',
+	operation: 'browser.navigation.operation',
 	pageCompletionTime: 'browser.navigation.page_completion_time',
 	pageSpanId: 'browser.navigation.page_span_id',
 	pctRelevant: 'browser.navigation.pct_relevant',

--- a/packages/web/src/index.ts
+++ b/packages/web/src/index.ts
@@ -651,6 +651,15 @@ export const SplunkRum: SplunkOtelWebType = {
 			}
 			const basicPlatformInfo = getBasicPlatformInfo(platformInfoOptions)
 
+			const spaMetricsManager =
+				processedOptions.spaMetrics === false
+					? undefined
+					: new SpaMetricsManager({
+							beaconEndpoint: processedOptions.beaconEndpoint,
+							...(processedOptions.spaMetrics === true ? {} : processedOptions.spaMetrics),
+						})
+			_spaMetricsManager = spaMetricsManager
+
 			this.attributesProcessor = new SpanAttributesProcessor(
 				this.sessionManager,
 				this.userManager,
@@ -665,6 +674,7 @@ export const SplunkRum: SplunkOtelWebType = {
 				},
 				processedOptions.discardDataAfterInactivity,
 				processedOptions.adjustSessionStartToTimeOrigin,
+				spaMetricsManager,
 			)
 
 			this._spanEmitter = new SpanEmitterProcessor()
@@ -699,15 +709,6 @@ export const SplunkRum: SplunkOtelWebType = {
 			})
 
 			this.sessionManager.start()
-
-			const spaMetricsManager =
-				processedOptions.spaMetrics === false
-					? undefined
-					: new SpaMetricsManager({
-							beaconEndpoint: processedOptions.beaconEndpoint,
-							...(processedOptions.spaMetrics === true ? {} : processedOptions.spaMetrics),
-						})
-			_spaMetricsManager = spaMetricsManager
 
 			const instrumentations = INSTRUMENTATIONS.map(({ confKey, disable, Instrument }) => {
 				const pluginConf = getPluginConfig(processedOptions.instrumentations[confKey], pluginDefaults, disable)

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -30,6 +30,7 @@ import { addSpanNetworkEvents, PerformanceEntries, PerformanceTimingNames as PTN
 import { SemanticAttributes, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions'
 
 import { SessionManager, SpaMetricsManager } from '../managers'
+import { BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION } from '../managers/spa-metrics-manager/constants'
 import { setBrowserNavigationPageAttributes } from '../managers/spa-metrics-manager/navigation-relevance'
 import { getPctMonitorTypes } from '../managers/spa-metrics-manager/resource-monitor-types'
 import { captureTraceParentFromPerformanceEntries } from '../servertiming'
@@ -103,7 +104,7 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 			if (span && spanName === AttributeNames.DOCUMENT_LOAD) {
 				span.setAttribute('component', this.component)
 				addExtraDocLoadTags(span)
-				this.spaMetricsManager?.setCurrentNavigationSpan(span, 0)
+				this.spaMetricsManager?.setCurrentNavigationSpan(span, 0, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 				// The span processor's automatic onStart event already ran before
 				// `component` was set, so emit manually now that SpanEmitter can
 				// route this as `document-load:start`.

--- a/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-document-load-instrumentation.ts
@@ -30,7 +30,10 @@ import { addSpanNetworkEvents, PerformanceEntries, PerformanceTimingNames as PTN
 import { SemanticAttributes, SEMATTRS_HTTP_URL } from '@opentelemetry/semantic-conventions'
 
 import { SessionManager, SpaMetricsManager } from '../managers'
-import { BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION } from '../managers/spa-metrics-manager/constants'
+import {
+	BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+	BROWSER_NAVIGATION_OPERATION_ATTRIBUTE,
+} from '../managers/spa-metrics-manager/constants'
 import { setBrowserNavigationPageAttributes } from '../managers/spa-metrics-manager/navigation-relevance'
 import { getPctMonitorTypes } from '../managers/spa-metrics-manager/resource-monitor-types'
 import { captureTraceParentFromPerformanceEntries } from '../servertiming'
@@ -102,6 +105,7 @@ export class SplunkDocumentLoadInstrumentation extends DocumentLoadInstrumentati
 			const span = _superStartSpan(spanName, performanceName, entries, parentSpan)
 
 			if (span && spanName === AttributeNames.DOCUMENT_LOAD) {
+				span.setAttribute(BROWSER_NAVIGATION_OPERATION_ATTRIBUTE, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 				span.setAttribute('component', this.component)
 				addExtraDocLoadTags(span)
 				this.spaMetricsManager?.setCurrentNavigationSpan(span, 0, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -20,6 +20,7 @@ import { diag, Span, trace, Tracer, TracerProvider } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
 import { SessionManager, SpaMetricsManager } from '../managers'
+import { BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION } from '../managers/spa-metrics-manager/constants'
 import { SplunkOtelWebConfig } from '../types'
 import { UserInteractionInstrumentation } from '../upstream/user-interaction/instrumentation'
 import { UserInteractionInstrumentationConfig } from '../upstream/user-interaction/types'
@@ -190,7 +191,7 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		}
 
 		const now = Date.now()
-		const span = this._routingTracer.startSpan('routeChange', { startTime: now })
+		const span = this._routingTracer.startSpan(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION, { startTime: now })
 		span.setAttribute('component', this.moduleName)
 		span.setAttribute('location.href', newHref)
 		span.setAttribute('prev.href', oldHref)
@@ -199,6 +200,7 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 			// Wait for all in-flight resources monitored by SPA metrics to finish loading,
 			// then resolve after a quiet period with no new monitored activity.
 			const pageLoadMetrics = await this.spaMetricsManager.waitForPageLoad({
+				operation: BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
 				span,
 				startTime: navigationStartTime,
 			})

--- a/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
+++ b/packages/web/src/instrumentations/splunk-user-interaction-instrumentation.ts
@@ -20,7 +20,10 @@ import { diag, Span, trace, Tracer, TracerProvider } from '@opentelemetry/api'
 import { isUrlIgnored } from '@opentelemetry/core'
 
 import { SessionManager, SpaMetricsManager } from '../managers'
-import { BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION } from '../managers/spa-metrics-manager/constants'
+import {
+	BROWSER_NAVIGATION_OPERATION_ATTRIBUTE,
+	BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+} from '../managers/spa-metrics-manager/constants'
 import { SplunkOtelWebConfig } from '../types'
 import { UserInteractionInstrumentation } from '../upstream/user-interaction/instrumentation'
 import { UserInteractionInstrumentationConfig } from '../upstream/user-interaction/types'
@@ -191,7 +194,12 @@ export class SplunkUserInteractionInstrumentation extends UserInteractionInstrum
 		}
 
 		const now = Date.now()
-		const span = this._routingTracer.startSpan(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION, { startTime: now })
+		const span = this._routingTracer.startSpan(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION, {
+			attributes: {
+				[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE]: BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+			},
+			startTime: now,
+		})
 		span.setAttribute('component', this.moduleName)
 		span.setAttribute('location.href', newHref)
 		span.setAttribute('prev.href', oldHref)

--- a/packages/web/src/managers/spa-metrics-manager/constants.ts
+++ b/packages/web/src/managers/spa-metrics-manager/constants.ts
@@ -21,11 +21,15 @@ export const BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE = 'browser.navig
 export const BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE = 'browser.navigation.loading_resource_count'
 export const BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE = 'browser.navigation.loading_resource_urls'
 export const BROWSER_NAVIGATION_LONGEST_LOADED_RESOURCE_ATTRIBUTE = 'browser.navigation.longest_loaded_resource'
+export const BROWSER_NAVIGATION_OPERATION_ATTRIBUTE = 'browser.navigation.operation'
 export const BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE = 'browser.navigation.page_completion_time'
 export const BROWSER_NAVIGATION_PAGE_SPAN_ID_ATTRIBUTE = 'browser.navigation.page_span_id'
 export const BROWSER_NAVIGATION_PCT_RELEVANT_ATTRIBUTE = 'browser.navigation.pct_relevant'
 export const BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE = 'browser.navigation.quiet_timer_reset_count'
 export const BROWSER_NAVIGATION_STATUS_ATTRIBUTE = 'browser.navigation.status'
+
+export const BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION = 'documentLoad'
+export const BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION = 'routeChange'
 
 export const PAGE_LOAD_METRICS_STATUS_COMPLETED = 'completed'
 export const PAGE_LOAD_METRICS_STATUS_INTERRUPTED = 'interrupted'

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -509,7 +509,11 @@ describe('SpaMetricsManager', () => {
 		manager.start()
 
 		try {
-			const result = await manager.waitForPageLoad({ span, startTime: performance.now() })
+			const result = await manager.waitForPageLoad({
+				operation: BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+				span,
+				startTime: performance.now(),
+			})
 
 			expect(attributes[BROWSER_NAVIGATION_PAGE_COMPLETION_TIME_ATTRIBUTE]).toBe(result.pct)
 			expect(attributes[BROWSER_NAVIGATION_STATUS_ATTRIBUTE]).toBe(result.status)
@@ -528,7 +532,11 @@ describe('SpaMetricsManager', () => {
 		manager.start()
 
 		try {
-			const promise = manager.waitForPageLoad({ span, startTime: performance.now() })
+			const promise = manager.waitForPageLoad({
+				operation: BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+				span,
+				startTime: performance.now(),
+			})
 
 			expect(manager.getCurrentNavigationSpanId()).toBe('navigation-span-id')
 
@@ -743,7 +751,11 @@ describe('SpaMetricsManager', () => {
 		}
 
 		try {
-			const promise = manager.waitForPageLoad({ span, startTime: performance.now() })
+			const promise = manager.waitForPageLoad({
+				operation: BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+				span,
+				startTime: performance.now(),
+			})
 
 			// @ts-expect-error onResourceStateChange is private. We use it for testing.
 			manager.onResourceStateChange({

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.test.ts
@@ -16,12 +16,13 @@
  *
  */
 
-import { diag, type Span } from '@opentelemetry/api'
+import { type Attributes, diag, type Span, TraceFlags } from '@opentelemetry/api'
 import { describe, expect, it, vi } from 'vitest'
 
 import { HTTP_TEST_SERVER_URL } from '../../../../../tests/servers/http-constants'
 import {
 	BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
 	BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
@@ -30,6 +31,7 @@ import {
 	BROWSER_NAVIGATION_PAGE_SPAN_ID_ATTRIBUTE,
 	BROWSER_NAVIGATION_PCT_RELEVANT_ATTRIBUTE,
 	BROWSER_NAVIGATION_QUIET_TIMER_RESET_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
 	BROWSER_NAVIGATION_STATUS_ATTRIBUTE,
 	PAGE_LOAD_METRICS_STATUS_COMPLETED,
 	PAGE_LOAD_METRICS_STATUS_INTERRUPTED,
@@ -42,15 +44,27 @@ import { getDocumentLoadTime, SpaMetricsManager } from './spa-metrics-manager'
 const TEST_API_URL = `${HTTP_TEST_SERVER_URL}/some-data`
 const TEST_BEACON_ENDPOINT = `${HTTP_TEST_SERVER_URL}/v1/rum`
 
-function createSpanMock(spanId = 'span-id'): { attributes: Record<string, boolean | number | string>; span: Span } {
-	const attributes: Record<string, boolean | number | string> = {}
-	const span = {
+function createSpanMock(spanId = 'span-id'): { attributes: Attributes; span: Span } {
+	const attributes: Attributes = {}
+	const span: Span = {
+		addEvent: () => span,
+		addLink: () => span,
+		addLinks: () => span,
+		end: vi.fn(),
+		isRecording: () => true,
+		recordException: vi.fn(),
 		setAttribute: (name: string, value: boolean | number | string) => {
 			attributes[name] = value
 			return span
 		},
-		spanContext: () => ({ spanId }),
-	} as Span
+		setAttributes: (values) => {
+			Object.assign(attributes, values)
+			return span
+		},
+		setStatus: () => span,
+		spanContext: () => ({ spanId, traceFlags: TraceFlags.NONE, traceId: '0'.repeat(32) }),
+		updateName: () => span,
+	}
 
 	return { attributes, span }
 }
@@ -532,7 +546,7 @@ describe('SpaMetricsManager', () => {
 		const { attributes: duringPctAttributes, span: duringPctSpan } = createSpanMock('during-pct-span-id')
 		const { attributes: afterPctAttributes, span: afterPctSpan } = createSpanMock('after-pct-span-id')
 
-		manager.setCurrentNavigationSpan(navigationSpan, 100)
+		manager.setCurrentNavigationSpan(navigationSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 		setBrowserNavigationPageAttributes(duringPctSpan, manager, 150, { type: 'document' })
 		manager.completeCurrentNavigationPct(navigationSpan, 200)
 		setBrowserNavigationPageAttributes(afterPctSpan, manager, 250, { type: 'document' })
@@ -543,6 +557,24 @@ describe('SpaMetricsManager', () => {
 		expect(afterPctAttributes[BROWSER_NAVIGATION_PCT_RELEVANT_ATTRIBUTE]).toBe(false)
 	})
 
+	it('stores the provided operation for document loads and route changes', () => {
+		const manager = new SpaMetricsManager()
+		const { span: documentLoadSpan } = createSpanMock('document-load-span-id')
+		const { span: routeChangeSpan } = createSpanMock('route-change-span-id')
+
+		manager.setCurrentNavigationSpan(documentLoadSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
+		manager.setCurrentNavigationSpan(routeChangeSpan, 200, BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION)
+
+		expect(manager.getNavigationOperation(150)).toBe(BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
+		expect(manager.getNavigationOperation(250)).toBe(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION)
+	})
+
+	it('defaults the navigation operation to documentLoad before a navigation span is registered', () => {
+		const manager = new SpaMetricsManager()
+
+		expect(manager.getNavigationOperation(0)).toBe('documentLoad')
+	})
+
 	it('derives PCT relevance from resource admission decisions', () => {
 		const manager = new SpaMetricsManager({
 			beaconEndpoint: 'https://rum.example/v1/rum',
@@ -551,7 +583,7 @@ describe('SpaMetricsManager', () => {
 			monitors: ['network'],
 		})
 		const { span: navigationSpan } = createSpanMock('navigation-span-id')
-		manager.setCurrentNavigationSpan(navigationSpan, 100)
+		manager.setCurrentNavigationSpan(navigationSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 
 		const resources = [
 			{ expected: true, id: 'admitted', monitorType: 'network' as const, startTime: 110, url: TEST_API_URL },
@@ -592,7 +624,7 @@ describe('SpaMetricsManager', () => {
 	it('claims only the closest admission decision for concurrent same-URL resources', () => {
 		const manager = new SpaMetricsManager({ monitors: ['network'] })
 		const { span: navigationSpan } = createSpanMock('navigation-span-id')
-		manager.setCurrentNavigationSpan(navigationSpan, 900)
+		manager.setCurrentNavigationSpan(navigationSpan, 900, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 
 		for (const [id, timestamp] of [
 			['first-request', 1000],
@@ -631,7 +663,7 @@ describe('SpaMetricsManager', () => {
 		const { span: navigationSpan } = createSpanMock('navigation-span-id')
 		const { attributes, span } = createSpanMock('long-task-span-id')
 
-		manager.setCurrentNavigationSpan(navigationSpan, 100)
+		manager.setCurrentNavigationSpan(navigationSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 		setBrowserNavigationPageAttributes(span, manager, 150)
 
 		expect(attributes[BROWSER_NAVIGATION_PAGE_SPAN_ID_ATTRIBUTE]).toBe('navigation-span-id')
@@ -643,8 +675,8 @@ describe('SpaMetricsManager', () => {
 		const { span: previousNavigationSpan } = createSpanMock('previous-navigation-span-id')
 		const { span: currentNavigationSpan } = createSpanMock('current-navigation-span-id')
 
-		manager.setCurrentNavigationSpan(previousNavigationSpan, 100)
-		manager.setCurrentNavigationSpan(currentNavigationSpan, 200)
+		manager.setCurrentNavigationSpan(previousNavigationSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
+		manager.setCurrentNavigationSpan(currentNavigationSpan, 200, BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION)
 		manager.completeCurrentNavigationPct(previousNavigationSpan, 250)
 
 		expect(manager.getCurrentNavigationSpanId()).toBe('current-navigation-span-id')
@@ -659,9 +691,9 @@ describe('SpaMetricsManager', () => {
 		const { span: firstNavigationSpan } = createSpanMock('first-navigation-span-id')
 		const { span: secondNavigationSpan } = createSpanMock('second-navigation-span-id')
 
-		manager.setCurrentNavigationSpan(firstNavigationSpan, 100)
+		manager.setCurrentNavigationSpan(firstNavigationSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 		manager.completeCurrentNavigationPct(firstNavigationSpan, 175)
-		manager.setCurrentNavigationSpan(secondNavigationSpan, 200)
+		manager.setCurrentNavigationSpan(secondNavigationSpan, 200, BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION)
 
 		expect(manager.getNavigationPageAttributes(150, { type: 'document' })).toEqual({
 			pageSpanId: 'first-navigation-span-id',
@@ -682,7 +714,12 @@ describe('SpaMetricsManager', () => {
 		const manager = new SpaMetricsManager()
 
 		for (let index = 0; index < 11; index++) {
-			manager.setCurrentNavigationSpan(createSpanMock(`navigation-${index}`).span, index * 100)
+			const span = createSpanMock(`navigation-${index}`).span
+			manager.setCurrentNavigationSpan(
+				span,
+				index * 100,
+				index === 0 ? BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION : BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+			)
 		}
 
 		expect(manager.getNavigationPageAttributes(50, { type: 'document' })).toBeUndefined()

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -25,6 +25,7 @@ import type { Monitor, MonitorConfig } from './monitors/monitor'
 import { truncateString } from '../../utils/text'
 import {
 	BROWSER_NAVIGATION_DETECTED_RESOURCE_COUNT_ATTRIBUTE,
+	BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
 	BROWSER_NAVIGATION_LAST_LOADED_RESOURCES_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_COUNT_ATTRIBUTE,
 	BROWSER_NAVIGATION_LOADING_RESOURCE_URLS_ATTRIBUTE,
@@ -102,11 +103,13 @@ type DroppedLoadingResources = {
 }
 
 type WaitForPageLoadConfig = {
+	operation?: string
 	span?: Span
 	startTime: number
 }
 
 type NavigationHistoryEntry = {
+	operation: string
 	pctEndTime?: number
 	spanId: string
 	startTime: number
@@ -221,6 +224,10 @@ export class SpaMetricsManager {
 		return this.navigationHistory.at(-1)?.spanId
 	}
 
+	getNavigationOperation(startTime: number): string {
+		return this.getNavigationAt(startTime)?.operation ?? BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION
+	}
+
 	getNavigationPageAttributes(
 		startTime: number,
 		activity?: NavigationActivity,
@@ -246,8 +253,8 @@ export class SpaMetricsManager {
 		}
 	}
 
-	setCurrentNavigationSpan(span: Span, startTime: number): void {
-		this.navigationHistory.push({ spanId: span.spanContext().spanId, startTime })
+	setCurrentNavigationSpan(span: Span, startTime: number, operation: string): void {
+		this.navigationHistory.push({ operation, spanId: span.spanContext().spanId, startTime })
 		// Keep the lookup bounded for long-running single-page applications.
 		if (this.navigationHistory.length > MAX_NAVIGATION_HISTORY_ENTRIES) {
 			this.navigationHistory.shift()
@@ -333,10 +340,10 @@ export class SpaMetricsManager {
 		diag.debug('SpaMetricsManager: Stopped monitoring.')
 	}
 
-	waitForPageLoad({ span, startTime }: WaitForPageLoadConfig): Promise<PageLoadMetricsResult> {
+	waitForPageLoad({ operation, span, startTime }: WaitForPageLoadConfig): Promise<PageLoadMetricsResult> {
 		this.quietPeriodAwaiter?.interrupt()
 		if (span) {
-			this.setCurrentNavigationSpan(span, startTime)
+			this.setCurrentNavigationSpan(span, startTime, operation ?? BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
 		}
 
 		const activeConfig = this.activeConfig

--- a/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
+++ b/packages/web/src/managers/spa-metrics-manager/spa-metrics-manager.ts
@@ -102,11 +102,17 @@ type DroppedLoadingResources = {
 	elementResourceUrls: string[]
 }
 
-type WaitForPageLoadConfig = {
-	operation?: string
-	span?: Span
-	startTime: number
-}
+type WaitForPageLoadConfig =
+	| {
+			operation: string
+			span: Span
+			startTime: number
+	  }
+	| {
+			operation?: never
+			span?: never
+			startTime: number
+	  }
 
 type NavigationHistoryEntry = {
 	operation: string
@@ -343,7 +349,7 @@ export class SpaMetricsManager {
 	waitForPageLoad({ operation, span, startTime }: WaitForPageLoadConfig): Promise<PageLoadMetricsResult> {
 		this.quietPeriodAwaiter?.interrupt()
 		if (span) {
-			this.setCurrentNavigationSpan(span, startTime, operation ?? BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
+			this.setCurrentNavigationSpan(span, startTime, operation)
 		}
 
 		const activeConfig = this.activeConfig

--- a/packages/web/src/span-processors/span-attributes-processor.ts
+++ b/packages/web/src/span-processors/span-attributes-processor.ts
@@ -21,11 +21,7 @@ import { hrTimeToMilliseconds } from '@opentelemetry/core'
 import { Span, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
 import { SESSION_DURATION_MS, SessionManager, SpaMetricsManager, UserManager } from '../managers'
-import {
-	BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
-	BROWSER_NAVIGATION_OPERATION_ATTRIBUTE,
-	BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
-} from '../managers/spa-metrics-manager/constants'
+import { BROWSER_NAVIGATION_OPERATION_ATTRIBUTE } from '../managers/spa-metrics-manager/constants'
 
 // Firefox can report navigation timings slightly before performance.timeOrigin.
 // Without this tolerance, [firefox] cookies > Connectivity events are captured can drop documentFetch spans.
@@ -71,16 +67,12 @@ export class SpanAttributesProcessor implements SpanProcessor {
 	}
 
 	onStart(span: Span): void {
-		if (this.spaMetricsManager) {
+		if (this.spaMetricsManager && span.attributes[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE] === undefined) {
 			const startTime = hrTimeToMilliseconds(span.startTime) - performance.timeOrigin
-			// Navigation spans reach processors before instrumentation registers them with SpaMetricsManager,
-			// so use their runtime names instead of looking up the previous navigation.
-			const operation =
-				span.name === BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION ||
-				span.name === BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION
-					? span.name
-					: this.spaMetricsManager.getNavigationOperation(startTime)
-			span.setAttribute(BROWSER_NAVIGATION_OPERATION_ATTRIBUTE, operation)
+			span.setAttribute(
+				BROWSER_NAVIGATION_OPERATION_ATTRIBUTE,
+				this.spaMetricsManager.getNavigationOperation(startTime),
+			)
 		}
 
 		if (span.attributes['location.href'] === undefined) {

--- a/packages/web/src/span-processors/span-attributes-processor.ts
+++ b/packages/web/src/span-processors/span-attributes-processor.ts
@@ -20,7 +20,12 @@ import { Attributes, diag } from '@opentelemetry/api'
 import { hrTimeToMilliseconds } from '@opentelemetry/core'
 import { Span, SpanProcessor } from '@opentelemetry/sdk-trace-base'
 
-import { SESSION_DURATION_MS, SessionManager, UserManager } from '../managers'
+import { SESSION_DURATION_MS, SessionManager, SpaMetricsManager, UserManager } from '../managers'
+import {
+	BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+	BROWSER_NAVIGATION_OPERATION_ATTRIBUTE,
+	BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+} from '../managers/spa-metrics-manager/constants'
 
 // Firefox can report navigation timings slightly before performance.timeOrigin.
 // Without this tolerance, [firefox] cookies > Connectivity events are captured can drop documentFetch spans.
@@ -35,6 +40,7 @@ export class SpanAttributesProcessor implements SpanProcessor {
 		globalAttributes: Attributes,
 		private readonly discardDataAfterInactivity: boolean = true,
 		private readonly adjustSessionStartToTimeOrigin: boolean = true,
+		private readonly spaMetricsManager?: SpaMetricsManager,
 	) {
 		this._globalAttributes = globalAttributes ?? {}
 	}
@@ -65,6 +71,18 @@ export class SpanAttributesProcessor implements SpanProcessor {
 	}
 
 	onStart(span: Span): void {
+		if (this.spaMetricsManager) {
+			const startTime = hrTimeToMilliseconds(span.startTime) - performance.timeOrigin
+			// Navigation spans reach processors before instrumentation registers them with SpaMetricsManager,
+			// so use their runtime names instead of looking up the previous navigation.
+			const operation =
+				span.name === BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION ||
+				span.name === BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION
+					? span.name
+					: this.spaMetricsManager.getNavigationOperation(startTime)
+			span.setAttribute(BROWSER_NAVIGATION_OPERATION_ATTRIBUTE, operation)
+		}
+
 		if (span.attributes['location.href'] === undefined) {
 			span.setAttribute('location.href', location.href)
 		}

--- a/packages/web/tests/splunk-span-attributes-processor.test.ts
+++ b/packages/web/tests/splunk-span-attributes-processor.test.ts
@@ -16,10 +16,20 @@
  *
  */
 
-import type { Span } from '@opentelemetry/sdk-trace-base'
+import {
+	AlwaysOffSampler,
+	BasicTracerProvider,
+	InMemorySpanExporter,
+	SimpleSpanProcessor,
+} from '@opentelemetry/sdk-trace-base'
 import { describe, expect, it } from 'vitest'
 
-import { SessionManager, StorageManager, UserManager } from '../src/managers'
+import { SessionManager, SpaMetricsManager, StorageManager, UserManager } from '../src/managers'
+import {
+	BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+	BROWSER_NAVIGATION_OPERATION_ATTRIBUTE,
+	BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+} from '../src/managers/spa-metrics-manager/constants'
 import { SpanAttributesProcessor } from '../src/span-processors'
 
 describe('SplunkSpanAttributesProcessor', () => {
@@ -58,25 +68,115 @@ describe('SplunkSpanAttributesProcessor', () => {
 			})
 		})
 
-		it('does not overwrite an existing location.href attribute on span start', () => {
+		it('does not overwrite an existing location.href attribute on span start', async () => {
 			const processor = new SpanAttributesProcessor(sessionManager, userManager, {}, true, false)
-			const attributes: Record<string, unknown> = {
-				'location.href': 'https://example.com/captured-route',
-			}
-			const span = {
-				attributes,
-				resource: { attributes: {} },
-				setAttribute: (key: string, value: unknown) => {
-					attributes[key] = value
-				},
-				setAttributes: (values: Record<string, unknown>) => {
-					Object.assign(attributes, values)
-				},
-			}
+			const { exporter, provider, tracer } = createTestTracer(processor)
+			const span = tracer.startSpan('captured-route', {
+				attributes: { 'location.href': 'https://example.com/captured-route' },
+			})
+			span.end()
+			await provider.forceFlush()
 
-			processor.onStart(span as unknown as Span)
+			expect(exporter.getFinishedSpans()[0].attributes['location.href']).toBe(
+				'https://example.com/captured-route',
+			)
+		})
 
-			expect(attributes['location.href']).toBe('https://example.com/captured-route')
+		it('sets the navigation operation that was active at the span start time', async () => {
+			const spaMetricsManager = new SpaMetricsManager()
+			const processor = new SpanAttributesProcessor(
+				sessionManager,
+				userManager,
+				{},
+				true,
+				false,
+				spaMetricsManager,
+			)
+			const { exporter, provider, tracer } = createTestTracer(processor)
+			const navigationSpan = tracer.startSpan(BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION, {
+				startTime: performance.timeOrigin + 100,
+			})
+			spaMetricsManager.setCurrentNavigationSpan(navigationSpan, 100, BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION)
+			const routeChangeSpan = tracer.startSpan(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION, {
+				startTime: performance.timeOrigin + 200,
+			})
+			spaMetricsManager.setCurrentNavigationSpan(routeChangeSpan, 200, BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION)
+
+			const documentLoadSpan = tracer.startSpan('document-load-span', {
+				startTime: performance.timeOrigin + 150,
+			})
+			const routeChangeOperationSpan = tracer.startSpan('route-change-span', {
+				startTime: performance.timeOrigin + 250,
+			})
+			documentLoadSpan.end()
+			routeChangeOperationSpan.end()
+			navigationSpan.end()
+			routeChangeSpan.end()
+			await provider.forceFlush()
+
+			const documentLoadAttributes = exporter
+				.getFinishedSpans()
+				.find((span) => span.name === 'document-load-span')?.attributes
+			const routeChangeAttributes = exporter
+				.getFinishedSpans()
+				.find((span) => span.name === 'route-change-span')?.attributes
+
+			expect(documentLoadAttributes?.[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE]).toBe(
+				BROWSER_NAVIGATION_DOCUMENT_LOAD_OPERATION,
+			)
+			expect(routeChangeAttributes?.[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE]).toBe(
+				BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+			)
+		})
+
+		it('attributes sampled spans after a sampled-out routeChange span without a name', async () => {
+			const spaMetricsManager = new SpaMetricsManager()
+			const processor = new SpanAttributesProcessor(
+				sessionManager,
+				userManager,
+				{},
+				true,
+				false,
+				spaMetricsManager,
+			)
+			const { exporter, provider, tracer } = createTestTracer(processor)
+			const sampledOutProvider = new BasicTracerProvider({ sampler: new AlwaysOffSampler() })
+			const sampledOutRouteChangeSpan = sampledOutProvider
+				.getTracer('sampled-out-route-change-test')
+				.startSpan(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION, { startTime: performance.timeOrigin + 200 })
+
+			expect('name' in sampledOutRouteChangeSpan).toBe(false)
+			spaMetricsManager.setCurrentNavigationSpan(
+				sampledOutRouteChangeSpan,
+				200,
+				BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+			)
+
+			const sampledSpan = tracer.startSpan('sampled-after-route-change', {
+				startTime: performance.timeOrigin + 250,
+			})
+			sampledSpan.end()
+			await provider.forceFlush()
+			await sampledOutProvider.shutdown()
+
+			const attributes = exporter
+				.getFinishedSpans()
+				.find((span) => span.name === 'sampled-after-route-change')?.attributes
+
+			expect(attributes?.[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE]).toBe(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION)
 		})
 	})
 })
+
+function createTestTracer(processor: SpanAttributesProcessor) {
+	const exporter = new InMemorySpanExporter()
+	const provider = new BasicTracerProvider()
+	provider.addSpanProcessor(processor)
+	provider.addSpanProcessor(new SimpleSpanProcessor(exporter))
+
+	return {
+		exporter,
+		provider,
+		tracer: provider.getTracer('span-attributes-processor-test'),
+	}
+}

--- a/packages/web/tests/splunk-span-attributes-processor.test.ts
+++ b/packages/web/tests/splunk-span-attributes-processor.test.ts
@@ -82,6 +82,30 @@ describe('SplunkSpanAttributesProcessor', () => {
 			)
 		})
 
+		it('does not overwrite an existing navigation operation on span start', async () => {
+			const spaMetricsManager = new SpaMetricsManager()
+			const processor = new SpanAttributesProcessor(
+				sessionManager,
+				userManager,
+				{},
+				true,
+				false,
+				spaMetricsManager,
+			)
+			const { exporter, provider, tracer } = createTestTracer(processor)
+			const span = tracer.startSpan(BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION, {
+				attributes: {
+					[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE]: BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+				},
+			})
+			span.end()
+			await provider.forceFlush()
+
+			expect(exporter.getFinishedSpans()[0].attributes[BROWSER_NAVIGATION_OPERATION_ATTRIBUTE]).toBe(
+				BROWSER_NAVIGATION_ROUTE_CHANGE_OPERATION,
+			)
+		})
+
 		it('sets the navigation operation that was active at the span start time', async () => {
 			const spaMetricsManager = new SpaMetricsManager()
 			const processor = new SpanAttributesProcessor(


### PR DESCRIPTION
## Summary

- add `browser.navigation.operation` to spans that contribute to browser metrics
- use `documentLoad` and `routeChange` values from the active SPA navigation
- cover document-load resources, route-change errors, page spans, and processor behavior

## Screenshots

<img width="1712" height="861" alt="image" src="https://github.com/user-attachments/assets/8d16bf92-c2e0-408a-b55d-cb4d192431b2" />
<img width="1719" height="866" alt="image" src="https://github.com/user-attachments/assets/15702900-7e6b-4aeb-afd6-18f1748e8743" />

## AI Attestation

This pull request was authored with OpenAI Codex. Codex implemented the code and tests, performed a local code review, and assisted with manual validation. The human author reviewed and directed the work.
